### PR TITLE
Defer receiving items on the title screen or while sleeping

### DIFF
--- a/worlds/ss/Constants.py
+++ b/worlds/ss/Constants.py
@@ -19,6 +19,9 @@ GIVE_ITEM_ARRAY_ADDR = 0x80678774  # ARRAY[16]
 # This is the address that holds the player's file name.
 FILE_NAME_ADDR = 0x80955D38  # ARRAY[16]
 
+# A bit at this address is set if on the title screen
+GLOBAL_TITLE_LOADER_ADDR = 0x80575780
+
 AP_VISITED_STAGE_NAMES_KEY_FORMAT = "ss_visited_stages_%i"
 
 LINK_INVALID_STATES = [
@@ -27,6 +30,8 @@ LINK_INVALID_STATES = [
     b'\x5A\x32\x8C', # Door
     b'\x5A\x12\xA8', # Diving
     b'\xB4\xF4\x50', # Bird picking up link
+    b'\x5A\x31\xAC', # Sleeping
+    b'\x5A\x33\x6C', # Waking up
 ]
 
 # Valid addresses for storyflags (ending in zero - final bit is added to this address)

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -307,7 +307,7 @@ async def _give_item(ctx: SSContext, item_name: str) -> bool:
     :param item_name: Name of the item to give.
     :return: Whether the item was successfully given.
     """
-    if not (check_link_state_for_giveitem() and check_alive()):
+    if not (check_link_state_for_giveitem() and check_alive() and not check_on_title_screen()):
         return False
 
     item_id = ITEM_TABLE[item_name].item_id  # In game item ID
@@ -331,7 +331,7 @@ async def give_items(ctx: SSContext) -> None:
 
     :param ctx: The SS client context.
     """
-    if check_link_state_for_giveitem() and check_alive():
+    if check_link_state_for_giveitem() and check_alive() and not check_on_title_screen():
         # Read the expected index of the player, which is the index of the latest item they've received.
         expected_idx = dme_read_short(EXPECTED_INDEX_ADDR)
 
@@ -462,7 +462,15 @@ def check_ingame() -> bool:
 
     :return: `True` if the player is in-game, otherwise `False`.
     """
-    return dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3) != 0x0
+    return int.from_bytes(dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)) != 0x0
+
+def check_on_title_screen() -> bool:
+    """
+    Check if the player is on the Title Screen.
+    
+    :return: `True` if the player is on the title screen, otherwise `False`.
+    """
+    return int.from_bytes(dolphin_memory_engine.read_bytes(GLOBAL_TITLE_LOADER_ADDR, 1)) != 0x0
 
 def check_link_state_for_giveitem() -> bool:
     """
@@ -470,7 +478,7 @@ def check_link_state_for_giveitem() -> bool:
 
     :return: True if Link is in a valid state, False if Link is in an invalid state
     """
-    linkstate = dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 4) != 0x0
+    linkstate = dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)
     if linkstate in LINK_INVALID_STATES:
         return False
     else:


### PR DESCRIPTION
## What is this fixing or adding?
Fixes issues where items could disappear if sent on the title screen or while sleeping. Also fixes subtle errors in Link state checking.


## How was this tested?
I used the AP client to send myself items while on the title screen or while in invalid states. The item correctly waited to be sent until I was in a valid state.

## If this makes graphical changes, please attach screenshots.
