### PR TITLE
More error proofing / improvements

### DIFF
--- a/worlds/ss/Constants.py
+++ b/worlds/ss/Constants.py
@@ -4,8 +4,19 @@ CURR_HEALTH_ADDR = 0x8095A76A  # HALFWORD
 # Link's state- make sure he is not in a loading zone
 CURR_STATE_ADDR = 0x80B76585
 
+# Link's action - make sure he is in a "normal" action (i.e. idle, moving on the ground, etc.)
+LINK_ACTION_ADDR = 0x80B7689B
+
+MAX_SAFE_ACTION = 0xD
+SWIMMING_ACTIONS = [0x4F, 0x50, 0x51]
+ITEM_GET_ACTION = 0x78
+
+# The byte at this address stores which save file is currently selected (0 indexed)
+SELECTED_FILE_ADDR = 0x8095FC98
+
 # The expected index for the following item that should be received. Array of 2 bytes right after the give item array
-EXPECTED_INDEX_ADDR = 0x80678784  # HALFWORD
+# Uses an unused scene index which is 16 bytes wide
+EXPECTED_INDEX_ADDR = 0x80956F28 # 0x80678784  # HALFWORD
 # WILL BE UPDATED WHEN THE BUILD IS RELEASED
 
 # This address contains the current stage ID.
@@ -13,8 +24,8 @@ CURR_STAGE_ADDR = 0x805B388C  # STRING[16]
 
 # This is an array of length 0x10 where each element is a byte and contains item IDs for items to give the player.
 # 0xFF represents no item. The array is read and cleared every frame.
-GIVE_ITEM_ARRAY_ADDR = 0x80678774  # ARRAY[16]
-# WILL BE UPDATED WHEN THE BUILD IS RELEASED
+GIVE_ITEM_ARRAY_ADDR = 0x8067877C  # ARRAY[16]
+# WILL BE UPDATED WHEN THE BUILD IS RELEASEDs
 
 # This is the address that holds the player's file name.
 FILE_NAME_ADDR = 0x80955D38  # ARRAY[16]
@@ -27,9 +38,10 @@ AP_VISITED_STAGE_NAMES_KEY_FORMAT = "ss_visited_stages_%i"
 LINK_INVALID_STATES = [
     b'\x00\x00\x00',
     b'\x5A\x2C\x88', # Loading zone
-    b'\x5A\x32\x8C', # Door
-    b'\x5A\x12\xA8', # Diving
+    b'\x5A\x32\x8C', # Door / talking to Bird Statue
+    # b'\x5A\x27\x20', # Calling Fi
     b'\xB4\xF4\x50', # Bird picking up link
+    # b'\xB7\xA6\x7C', # Bed dialogue option
     b'\x5A\x31\xAC', # Sleeping
     b'\x5A\x33\x6C', # Waking up
 ]
@@ -85,13 +97,13 @@ FORCED_OPTIONS = {
     # Options, for now, that must be a certain value
     # Also serves as a list for me for what needs to be implemented
     "map_mode": 4, # Anywhere
-    "small_key_mode": 3, # Anywhere
-    "boss_key_mode": 2, # Anywhere
+    # "small_key_mode": 3, # Anywhere
+    # "boss_key_mode": 2, # Anywhere
     "random_start_entrance": 0, # Vanilla, not logically implemented
     "random_start_statues": 0, # False
     "rupeesanity": 1, # True
     "gondo_upgrades": 1, # True
-    "bit_patches": 0, # Disable
+    # "bit_patches": 0, # Disable
     "song_hints": 0, # None
     "chest_dowsing": 0, # Vanilla
     "impa_sot_hint": 0, # False

--- a/worlds/ss/Constants.py
+++ b/worlds/ss/Constants.py
@@ -8,7 +8,6 @@ CURR_STATE_ADDR = 0x80B76585
 LINK_ACTION_ADDR = 0x80B7689B
 
 MAX_SAFE_ACTION = 0xD
-SWIMMING_ACTIONS = [0x4F, 0x50, 0x51]
 ITEM_GET_ACTION = 0x78
 
 # The byte at this address stores which save file is currently selected (0 indexed)
@@ -16,7 +15,7 @@ SELECTED_FILE_ADDR = 0x8095FC98
 
 # The expected index for the following item that should be received. Array of 2 bytes right after the give item array
 # Uses an unused scene index which is 16 bytes wide
-EXPECTED_INDEX_ADDR = 0x80956F28 # 0x80678784  # HALFWORD
+EXPECTED_INDEX_ADDR = 0x80956F28 # HALFWORD
 # WILL BE UPDATED WHEN THE BUILD IS RELEASED
 
 # This address contains the current stage ID.

--- a/worlds/ss/Options.py
+++ b/worlds/ss/Options.py
@@ -484,8 +484,8 @@ class BiTPatches(Choice):
 
     display_name = "BiT Patches"
     option_disable = 0
-    # option_vanilla = 1
-    # option_fix_crashes = 2
+    option_vanilla = 1
+    option_fix_crashes = 2
     default = 0 # 1
 
 

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -354,7 +354,7 @@ async def give_items(ctx: SSContext) -> None:
             if expected_idx <= idx:
                 # Attempt to give the item and increment the expected index.
                 while not await _give_item(ctx, LOOKUP_ID_TO_NAME[item.item]):
-                    await asyncio.sleep(0.5)
+                    await asyncio.sleep(1)
 
                 # Increment the expected index.
                 dme_write_short(EXPECTED_INDEX_ADDR, idx + 1)
@@ -483,13 +483,13 @@ def check_on_title_screen() -> bool:
     
     :return: `True` if the player is on the title screen, otherwise `False`.
     """
-    return dolphin_memory_engine.read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
+    return dme_read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
 
 def get_link_state() -> bytes:
     return dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)
 
 def get_link_action() -> int:
-    return dolphin_memory_engine.read_byte(LINK_ACTION_ADDR)
+    return dme_read_byte(LINK_ACTION_ADDR)
 
 def validate_link_state() -> bool:
     """
@@ -508,8 +508,8 @@ def validate_link_action() -> bool:
 
     :return: True if Link is in a safe action, False if Link is not in a safe action.
     """
-    action = dolphin_memory_engine.read_byte(LINK_ACTION_ADDR)
-    return action <= MAX_SAFE_ACTION or action in SWIMMING_ACTIONS
+    action = dme_read_byte(LINK_ACTION_ADDR)
+    return action <= MAX_SAFE_ACTION or (action == ITEM_GET_ACTION)
 
 def check_on_file_1() -> bool:
     """
@@ -517,7 +517,7 @@ def check_on_file_1() -> bool:
 
     :return: True if File 1 last selected, False otherwise
     """
-    file = dolphin_memory_engine.read_byte(SELECTED_FILE_ADDR)
+    file = dme_read_byte(SELECTED_FILE_ADDR)
     return file == 0
 
 def can_receive_items() -> bool:

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -307,7 +307,7 @@ async def _give_item(ctx: SSContext, item_name: str) -> bool:
     :param item_name: Name of the item to give.
     :return: Whether the item was successfully given.
     """
-    if not (check_link_state_for_giveitem() and check_alive() and not check_on_title_screen()):
+    if not can_receive_items():
         return False
 
     item_id = ITEM_TABLE[item_name].item_id  # In game item ID
@@ -316,9 +316,22 @@ async def _give_item(ctx: SSContext, item_name: str) -> bool:
     for idx in range(ctx.len_give_item_array):
         slot = dme_read_byte(GIVE_ITEM_ARRAY_ADDR + idx)
         if slot == 0xFF:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.25)
             logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
             dme_write_byte(GIVE_ITEM_ARRAY_ADDR + idx, item_id)
+            await asyncio.sleep(0.25)
+            # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
+            # or bed which could delete the item, so we should check for a reload
+            if get_link_action() != ITEM_GET_ACTION:  
+                # logger.info(f"DEBUG: Player did not immediately receive item. Watching for a reload...")
+                while get_link_action() != ITEM_GET_ACTION:
+                    await asyncio.sleep(0.1)
+                    # If state is 0, that means a reload occurred, so we should resend the item.
+                    if int.from_bytes(get_link_state()) == 0x0:
+                        # logger.info(f"DEBUG: A reload occurred! Resending the item...")
+                        dme_write_byte(GIVE_ITEM_ARRAY_ADDR + idx, item_id)
+                        break
+            
             return True
 
     # If unable to place the item in the array, return False.
@@ -331,7 +344,7 @@ async def give_items(ctx: SSContext) -> None:
 
     :param ctx: The SS client context.
     """
-    if check_link_state_for_giveitem() and check_alive() and not check_on_title_screen():
+    if can_receive_items():
         # Read the expected index of the player, which is the index of the latest item they've received.
         expected_idx = dme_read_short(EXPECTED_INDEX_ADDR)
 
@@ -341,7 +354,7 @@ async def give_items(ctx: SSContext) -> None:
             if expected_idx <= idx:
                 # Attempt to give the item and increment the expected index.
                 while not await _give_item(ctx, LOOKUP_ID_TO_NAME[item.item]):
-                    await asyncio.sleep(1)
+                    await asyncio.sleep(0.5)
 
                 # Increment the expected index.
                 dme_write_short(EXPECTED_INDEX_ADDR, idx + 1)
@@ -356,42 +369,44 @@ async def check_locations(ctx: SSContext) -> None:
 
     :param ctx: The SS client context.
     """
-    # Loop through all locations to see if each has been checked.
-    for location, data in LOCATION_TABLE.items():
-        checked = False
-        [flag_type, flag_bit, flag_value, addr] = data.checked_flag
-        if flag_type == SSLocCheckedFlag.STORY:
-            flag = dme_read_byte(addr + flag_bit)
-            checked = bool(flag & flag_value)
-        elif flag_type == SSLocCheckedFlag.SCENE:
-            flag = dme_read_byte(STAGE_TO_SCENEFLAG_ADDR[addr] + flag_bit)
-            checked = bool(flag & flag_value)
-        elif flag_type == SSLocCheckedFlag.SPECL:
-            if location == "Upper Skyloft - Ghost/Pipit's Crystals":
-                flag1 = bool(dme_read_byte(0x805A9B16) & 0x80)  # 5 crystals from Pipit
-                flag2 = bool(dme_read_byte(0x805A9B16) & 0x04)  # 5 crystals from Ghost
-                checked = flag1 or flag2
-            if location == "Central Skyloft - Peater/Peatrice's Crystals":
-                flag1 = bool(
-                    dme_read_byte(0x805A9B1A) & 0x40
-                )  # 5 crystals from Peatrice
-                flag2 = bool(dme_read_byte(0x805A9B1D) & 0x02)  # 5 crystals from Peater
-                checked = flag1 or flag2
+    # Don't send locations from the title screen (BiT)
+    if can_send_items():
+        # Loop through all locations to see if each has been checked.
+        for location, data in LOCATION_TABLE.items():
+            checked = False
+            [flag_type, flag_bit, flag_value, addr] = data.checked_flag
+            if flag_type == SSLocCheckedFlag.STORY:
+                flag = dme_read_byte(addr + flag_bit)
+                checked = bool(flag & flag_value)
+            elif flag_type == SSLocCheckedFlag.SCENE:
+                flag = dme_read_byte(STAGE_TO_SCENEFLAG_ADDR[addr] + flag_bit)
+                checked = bool(flag & flag_value)
+            elif flag_type == SSLocCheckedFlag.SPECL:
+                if location == "Upper Skyloft - Ghost/Pipit's Crystals":
+                    flag1 = bool(dme_read_byte(0x805A9B16) & 0x80)  # 5 crystals from Pipit
+                    flag2 = bool(dme_read_byte(0x805A9B16) & 0x04)  # 5 crystals from Ghost
+                    checked = flag1 or flag2
+                if location == "Central Skyloft - Peater/Peatrice's Crystals":
+                    flag1 = bool(
+                        dme_read_byte(0x805A9B1A) & 0x40
+                    )  # 5 crystals from Peatrice
+                    flag2 = bool(dme_read_byte(0x805A9B1D) & 0x02)  # 5 crystals from Peater
+                    checked = flag1 or flag2
 
-        if checked:
-            if data.code is None:  # Defeat Demise
-                if not ctx.finished_game:
-                    await ctx.send_msgs(
-                        [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
-                    )
-                    ctx.finished_game = True
-            else:
-                ctx.locations_checked.add(SSLocation.get_apid(data.code))
+            if checked:
+                if data.code is None:  # Defeat Demise
+                    if not ctx.finished_game:
+                        await ctx.send_msgs(
+                            [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
+                        )
+                        ctx.finished_game = True
+                else:
+                    ctx.locations_checked.add(SSLocation.get_apid(data.code))
 
-    # Send the list of newly-checked locations to the server.
-    locations_checked = ctx.locations_checked.difference(ctx.checked_locations)
-    if locations_checked:
-        await ctx.send_msgs([{"cmd": "LocationChecks", "locations": locations_checked}]) 
+        # Send the list of newly-checked locations to the server.
+        locations_checked = ctx.locations_checked.difference(ctx.checked_locations)
+        if locations_checked:
+            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": locations_checked}]) 
 
 
 async def check_current_stage_changed(ctx: SSContext) -> None:
@@ -468,20 +483,54 @@ def check_on_title_screen() -> bool:
     
     :return: `True` if the player is on the title screen, otherwise `False`.
     """
-    return int.from_bytes(dolphin_memory_engine.read_bytes(GLOBAL_TITLE_LOADER_ADDR, 1)) != 0x0
+    return dolphin_memory_engine.read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
 
-def check_link_state_for_giveitem() -> bool:
+def get_link_state() -> bytes:
+    return dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)
+
+def get_link_action() -> int:
+    return dolphin_memory_engine.read_byte(LINK_ACTION_ADDR)
+
+def validate_link_state() -> bool:
     """
     Returns a bool determining whether Link is in a valid or invalid state to receive items.
 
     :return: True if Link is in a valid state, False if Link is in an invalid state
     """
-    linkstate = dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)
-    if linkstate in LINK_INVALID_STATES:
+    if get_link_state() in LINK_INVALID_STATES:
         return False
     else:
         return True
 
+def validate_link_action() -> bool:
+    """
+    Returns a bool determining if Link is in a safe action to receive items.
+
+    :return: True if Link is in a safe action, False if Link is not in a safe action.
+    """
+    action = dolphin_memory_engine.read_byte(LINK_ACTION_ADDR)
+    return action <= MAX_SAFE_ACTION or action in SWIMMING_ACTIONS
+
+def check_on_file_1() -> bool:
+    """
+    Returns a bool determining if the player is currently on File 1.
+
+    :return: True if File 1 last selected, False otherwise
+    """
+    file = dolphin_memory_engine.read_byte(SELECTED_FILE_ADDR)
+    return file == 0
+
+def can_receive_items() -> bool:
+    """
+    Link must be on File 1 in a valid state and action and not on the title screen to receive items.
+    """
+    return can_send_items() and check_alive() and validate_link_state() and validate_link_action()
+
+def can_send_items() -> bool:
+    """
+    Link must be on File 1 and not on the tile screen to send items.
+    """
+    return (not check_on_title_screen()) and check_on_file_1()
 
 async def dolphin_sync_task(ctx: SSContext) -> None:
     """


### PR DESCRIPTION
## What is this fixing or adding?
Fixes some issues that caused received items to be deleted. Allows BiT support by only sending/receiving items when playing normally on File 1.

## How was this tested?
I went through extensive trial and error, checking various situations to ensure items are only sent and received at the right times.