### PR TITLE
Fix generator warnings about per_world_random, fix FFW handling, more deleted/duped item-proofing

### DIFF
--- a/worlds/ss/Constants.py
+++ b/worlds/ss/Constants.py
@@ -15,6 +15,8 @@ ITEM_GET_ACTION = 0x78
 DOOR_ACTIONS = [0x6E, 0x6F]
 SWIM_ACTIONS = [0x4F, 0x50, 0x51, 0x52]
 
+DEMISE_STAGE = "B400"
+
 # The byte at this address stores which save file is currently selected (0 indexed)
 SELECTED_FILE_ADDR = 0x8095FC98
 

--- a/worlds/ss/Constants.py
+++ b/worlds/ss/Constants.py
@@ -7,8 +7,13 @@ CURR_STATE_ADDR = 0x80B76585
 # Link's action - make sure he is in a "normal" action (i.e. idle, moving on the ground, etc.)
 LINK_ACTION_ADDR = 0x80B7689B
 
+# Some memory addresses are offset by this value in FFW. I dunno why.
+FFW_MEMORY_OFFSET = 0x8960
+
 MAX_SAFE_ACTION = 0xD
 ITEM_GET_ACTION = 0x78
+DOOR_ACTIONS = [0x6E, 0x6F]
+SWIM_ACTIONS = [0x4F, 0x50, 0x51, 0x52]
 
 # The byte at this address stores which save file is currently selected (0 indexed)
 SELECTED_FILE_ADDR = 0x8095FC98

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -71,6 +71,7 @@ class SSContext(CommonContext):
         self.awaiting_rom: bool = False
         self.last_rcvd_index: int = -1
         self.has_send_death: bool = False
+        self.in_ffw: bool = False
 
         # Name of the current stage as read from the game's memory. Sent to trackers whenever its value changes to
         # facilitate automatically switching to the map of the current stage.
@@ -307,7 +308,7 @@ async def _give_item(ctx: SSContext, item_name: str) -> bool:
     :param item_name: Name of the item to give.
     :return: Whether the item was successfully given.
     """
-    if not can_receive_items():
+    if not can_receive_items(ctx.in_ffw):
         return False
 
     item_id = ITEM_TABLE[item_name].item_id  # In game item ID
@@ -322,19 +323,24 @@ async def _give_item(ctx: SSContext, item_name: str) -> bool:
             await asyncio.sleep(0.25)
             # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
             # or bed which could delete the item, so we should check for a reload
-            if get_link_action() != ITEM_GET_ACTION:  
-                logger.info(f"DEBUG: Player did not immediately receive item. Watching for a reload...")
-                while get_link_action() != ITEM_GET_ACTION:
-                    await asyncio.sleep(0.1)
-                    # Stop trying if the player soft reset
-                    if check_on_title_screen():
-                        break
-                        
-                    # If state is 0, that means a reload occurred, so we should resend the item.
-                    if int.from_bytes(get_link_state()) == 0x0:
-                        logger.info(f"DEBUG: A reload occurred! Resending the item...")
-                        dme_write_byte(GIVE_ITEM_ARRAY_ADDR + idx, item_id)
-                        break
+            while get_link_action(ctx.in_ffw) != ITEM_GET_ACTION:
+                await asyncio.sleep(0.1)
+                # Stop trying if the player soft reset
+                # Also stop trying if the player is using a door, since doors don't actually delete items
+                # And, while the client won't initiate an item send while the player is swimming, the player
+                # can still receive items when going through underwater loading zones, as their action will
+                # momentarily be action 0x03.
+                # The patched game *will* still give them the item, but it won't give them the item action,
+                # so we shouldn't resend the item, or else it will be duplicated.
+                if check_on_title_screen() or get_link_action(ctx.in_ffw) in DOOR_ACTIONS + SWIM_ACTIONS:
+                    break
+                    
+                # If state is 0, that means a reload occurred, so we should resend the item.
+                # However, we shouldn't resend the item if the user immediately enters the item get action anyway
+                # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
+                if not check_ingame(ctx.in_ffw):
+                    logger.info(f"DEBUG: A reload deleted the item. Resending the item...")
+                    return False
             
             return True
 
@@ -348,7 +354,7 @@ async def give_items(ctx: SSContext) -> None:
 
     :param ctx: The SS client context.
     """
-    if can_receive_items():
+    if can_receive_items(ctx.in_ffw):
         # Read the expected index of the player, which is the index of the latest item they've received.
         expected_idx = dme_read_short(EXPECTED_INDEX_ADDR)
 
@@ -424,6 +430,8 @@ async def check_current_stage_changed(ctx: SSContext) -> None:
     new_stage_name = dme_read_string(CURR_STAGE_ADDR, 16)
 
     current_stage_name = ctx.current_stage_name
+    ctx.in_ffw = "F103" in new_stage_name
+
     if new_stage_name != current_stage_name:
         ctx.current_stage_name = new_stage_name
         # Send a Bounced message containing the new stage name to all trackers connected to the current slot.
@@ -473,13 +481,13 @@ async def check_death(ctx: SSContext) -> None:
             ctx.has_send_death = False
 
 
-def check_ingame() -> bool:
+def check_ingame(in_ffw: bool = False) -> bool:
     """
     Check if the player is currently in-game.
 
     :return: `True` if the player is in-game, otherwise `False`.
     """
-    return int.from_bytes(dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)) != 0x0
+    return int.from_bytes(get_link_state(in_ffw)) != 0x0
 
 def check_on_title_screen() -> bool:
     """
@@ -489,30 +497,30 @@ def check_on_title_screen() -> bool:
     """
     return dme_read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
 
-def get_link_state() -> bytes:
-    return dolphin_memory_engine.read_bytes(CURR_STATE_ADDR, 3)
+def get_link_state(in_ffw: bool = False) -> bytes:
+    return dolphin_memory_engine.read_bytes(CURR_STATE_ADDR - (FFW_MEMORY_OFFSET if in_ffw else 0), 3)
 
-def get_link_action() -> int:
-    return dme_read_byte(LINK_ACTION_ADDR)
+def get_link_action(in_ffw: bool = False) -> int:
+    return dme_read_byte(LINK_ACTION_ADDR - (FFW_MEMORY_OFFSET if in_ffw else 0))
 
-def validate_link_state() -> bool:
+def validate_link_state(in_ffw: bool = False) -> bool:
     """
     Returns a bool determining whether Link is in a valid or invalid state to receive items.
 
     :return: True if Link is in a valid state, False if Link is in an invalid state
     """
-    if get_link_state() in LINK_INVALID_STATES:
+    if get_link_state(in_ffw) in LINK_INVALID_STATES:
         return False
     else:
         return True
 
-def validate_link_action() -> bool:
+def validate_link_action(in_ffw: bool = False) -> bool:
     """
     Returns a bool determining if Link is in a safe action to receive items.
 
     :return: True if Link is in a safe action, False if Link is not in a safe action.
     """
-    action = dme_read_byte(LINK_ACTION_ADDR)
+    action = dme_read_byte(LINK_ACTION_ADDR - (FFW_MEMORY_OFFSET if in_ffw else 0))
     return action <= MAX_SAFE_ACTION or (action == ITEM_GET_ACTION)
 
 def check_on_file_1() -> bool:
@@ -524,11 +532,11 @@ def check_on_file_1() -> bool:
     file = dme_read_byte(SELECTED_FILE_ADDR)
     return file == 0
 
-def can_receive_items() -> bool:
+def can_receive_items(in_ffw: bool = False) -> bool:
     """
     Link must be on File 1 in a valid state and action and not on the title screen to receive items.
     """
-    return can_send_items() and check_alive() and validate_link_state() and validate_link_action()
+    return can_send_items() and check_alive() and validate_link_state(in_ffw) and validate_link_action(in_ffw)
 
 def can_send_items() -> bool:
     """
@@ -551,7 +559,7 @@ async def dolphin_sync_task(ctx: SSContext) -> None:
                 dolphin_memory_engine.is_hooked()
                 and ctx.dolphin_status == CONNECTION_CONNECTED_STATUS
             ):
-                if not check_ingame():
+                if not check_ingame(ctx.in_ffw):
                     # Reset the give item array while not in the game.
                     # dolphin_memory_engine.write_bytes(GIVE_ITEM_ARRAY_ADDR, bytes([0xFF] * ctx.len_give_item_array))
                     await asyncio.sleep(0.1)

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -320,7 +320,7 @@ class SSWorld(World):
         multiworld = self.multiworld
         player = self.player
         hints = Hints(self)
-        player_hash = self.multiworld.per_slot_randoms[player].sample(HASH_NAMES, 3)
+        player_hash = self.random.sample(HASH_NAMES, 3)
         mw_player_names = [
             self.multiworld.get_player_name(i + 1)
             for i in range(self.multiworld.players)
@@ -332,7 +332,7 @@ class SSWorld(World):
             "World Version": list(WORLD_VERSION),
             "Hash": f"AP P{player} " + " ".join(player_hash),
             "AP Seed": multiworld.seed_name,
-            "Rando Seed": self.multiworld.per_slot_randoms[player].randint(
+            "Rando Seed": self.random.randint(
                 0, 2**32 - 1
             ),
             "Slot": player,


### PR DESCRIPTION
## What is this fixing or adding?
Title.

## How was this tested?
I repeated previous tests with item deletion edge cases, confirming they still worked as expected (give item again if interrupted by fiwarp/bed, don't give item again if by door).
I gave myself an item underwater, swam into the Great Tree, which gave me the item (and stopped the client from resending it upon a reload).
I generated an AP seed with the generator and didn't get any warnings.