### PR TITLE
Broadcast Hints to the Server

### DIFF
--- a/worlds/ss/Hints.py
+++ b/worlds/ss/Hints.py
@@ -26,6 +26,9 @@ class SSHint(NamedTuple):
     code: int
     region: str
     type: SSHintType
+    checked_flag: list[
+        int, int, int
+    ]  # [ flag_bit (0x0-0xF), flag_value (0x01-0x80), story flag address (ending in zero)]
 
 
 class SSLocationHint:
@@ -90,116 +93,139 @@ HINT_TABLE: dict[str, SSHint] = {
         0,
         None,
         SSHintType.FI,
+        [0xD, 0x10, 0x805A9AD0],  # Flag 36 (Tunic)
     ),
     "Central Skyloft - Gossip Stone on Waterfall Island": SSHint(
         1,
         "Central Skyloft",
         SSHintType.STONE,
+        [0x3, 0x40, 0x805A9B40],  # Flag 960
     ),
     "Sky - Gossip Stone on Lumpy Pumpkin": SSHint(
         2,
         "Sky",
         SSHintType.STONE,
+        [0x3, 0x80, 0x805A9B40],  # Flag 961
     ),
     "Sky - Gossip Stone on Volcanic Island": SSHint(
         3,
         "Sky",
         SSHintType.STONE,
+        [0x2, 0x01, 0x805A9B40],  # Flag 962
     ),
     "Sky - Gossip Stone on Bamboo Island": SSHint(
         4,
         "Sky",
         SSHintType.STONE,
+        [0x2, 0x02, 0x805A9B40],  # Flag 963
     ),
     "Thunderhead - Gossip Stone near Bug Heaven": SSHint(
         5,
         "Thunderhead",
         SSHintType.STONE,
+        [0x2, 0x04, 0x805A9B40],  # Flag 964
     ),
     "Sealed Grounds - Gossip Stone behind the Temple": SSHint(
         6,
         "Sealed Grounds",
         SSHintType.STONE,
+        [0x2, 0x08, 0x805A9B40],  # Flag 965
     ),
     "Faron Woods - Gossip Stone in Deep Woods": SSHint(
         7,
         "Faron Woods",
         SSHintType.STONE,
+        [0x2, 0x10, 0x805A9B40],  # Flag 966
     ),
     "Lake Floria - Gossip Stone outside Ancient Cistern": SSHint(
         8,
         "Lake Floria",
         SSHintType.STONE,
+        [0x2, 0x20, 0x805A9B40],  # Flag 967
     ),
     "Eldin Volcano - Gossip Stone next to Earth Temple": SSHint(
         9,
         "Eldin Volcano",
         SSHintType.STONE,
+        [0x2, 0x40, 0x805A9B40],  # Flag 968
     ),
     "Eldin Volcano - Gossip Stone in Thrill Digger Cave": SSHint(
         10,
         "Eldin Volcano",
         SSHintType.STONE,
+        [0x2, 0x80, 0x805A9B40],  # Flag 969
     ),
     "Eldin Volcano - Gossip Stone in Lower Platform Cave": SSHint(
         11,
         "Eldin Volcano",
         SSHintType.STONE,
+        [0x5, 0x01, 0x805A9B40],  # Flag 970
     ),
     "Eldin Volcano - Gossip Stone in Upper Platform Cave": SSHint(
         12,
         "Eldin Volcano",
         SSHintType.STONE,
+        [0x5, 0x02, 0x805A9B40],  # Flag 971
     ),
     "Volcano Summit - Gossip Stone near Second Thirsty Frog": SSHint(
         13,
         "Volcano Summit",
         SSHintType.STONE,
+        [0x5, 0x04, 0x805A9B40],  # Flag 972
     ),
     "Volcano Summit - Gossip Stone in Waterfall Area": SSHint(
         14,
         "Volcano Summit",
         SSHintType.STONE,
+        [0x5, 0x08, 0x805A9B40],  # Flag 973
     ),
     "Temple of Time - Gossip Stone in Temple of Time Area": SSHint(
         15,
         "Lanayru Desert",
         SSHintType.STONE,
+        [0x5, 0x10, 0x805A9B40],  # Flag 974
     ),
     "Lanayru Sand Sea - Gossip Stone in Shipyard": SSHint(
         16,
         "Lanayru Sand Sea",
         SSHintType.STONE,
+        [0x5, 0x20, 0x805A9B40],  # Flag 975
     ),
     "Lanayru Caves - Gossip Stone in Center": SSHint(
         17,
         "Lanayru Caves",
         SSHintType.STONE,
+        [0x5, 0x40, 0x805A9B40],  # Flag 976
     ),
     "Lanayru Caves - Gossip Stone towards Lanayru Gorge": SSHint(
         18,
         "Lanayru Caves",
         SSHintType.STONE,
+        [0x5, 0x80, 0x805A9B40],  # Flag 977
     ),
     "Song of the Hero - Trial Hint": SSHint(
         19,
         None,
         SSHintType.SONG,
+        [0x3, 0x80, 0x805A9B00],  # Flag 369
     ),
     "Farore's Courage - Trial Hint": SSHint(
         20,
         None,
         SSHintType.SONG,
+        [0x5, 0x80, 0x805A9AE0],  # Flag 71
     ),
     "Nayru's Wisdom - Trial Hint": SSHint(
         21,
         None,
         SSHintType.SONG,
+        [0x9, 0x20, 0x805A9AE0],  # Flag 72
     ),
     "Din's Power - Trial Hint": SSHint(
         22,
         None,
         SSHintType.SONG,
+        [0x9, 0x40, 0x805A9AE0],  # Flag 73
     ),
 }
 

--- a/worlds/ss/Rando/HintPlacement.py
+++ b/worlds/ss/Rando/HintPlacement.py
@@ -4,7 +4,7 @@ from BaseClasses import ItemClassification as IC
 
 from ..Hints import *
 from ..Items import ITEM_TABLE
-from ..Locations import SSLocType, LOCATION_TABLE
+from ..Locations import SSLocType, LOCATION_TABLE, SSLocation
 
 from .ItemPlacement import item_classification
 
@@ -22,6 +22,7 @@ class Hints:
         self.multiworld = world.multiworld
 
         self.placed_hints: dict[str, list] = {}
+        self.locations_for_hint: dict[str, list] = {}
         self.hinted_locations: list[str] = []
         self.hinted_item_locations: list = []
         self.distribution_option = self.world.options.hint_distribution
@@ -110,6 +111,7 @@ class Hints:
                 for _ in range(self.distribution["fi"]):
                     fi_hints.append(self.all_hints.pop())
                 self.placed_hints["Fi"] = [fh.to_fi_text() for fh in fi_hints]
+                self.locations_for_hint["Fi"] = [fh.location for fh in fi_hints if isinstance(fh, SSLocationHint)]
             elif data.type == SSHintType.STONE:
                 stone_hints = []
                 for _ in range(self.distribution["hints_per_stone"]):
@@ -117,6 +119,7 @@ class Hints:
                 self.placed_hints[hint] = [
                     sh.to_gossip_stone_text() for sh in stone_hints
                 ]
+                self.locations_for_hint[hint] = [sh.location for sh in stone_hints if isinstance(sh, SSLocationHint)]
             elif data.type == SSHintType.SONG:
                 self.placed_hints[hint] = self._handle_song_hints(hint)
 
@@ -286,6 +289,7 @@ class Hints:
             else:
                 return [useless_text]
         if self.world.options.song_hints == "direct":
+            self.locations_for_hint[hint] = [f"{trial_connection} - Trial Reward"]
             player_name = self.multiworld.get_player_name(trial_item.player)
             item_name = trial_item.name
             return [direct_text.format(plr=player_name, itm=item_name)]

--- a/worlds/ss/Rando/ItemPlacement.py
+++ b/worlds/ss/Rando/ItemPlacement.py
@@ -110,8 +110,15 @@ def _create_itempool(world: "SSWorld") -> tuple[list[str], list[str]]:
         for loc, data in LOCATION_TABLE.items():
             if data.type == SSLocType.CLEF:
                 itm = "Group of Tadtones"
-                progression_pool.remove(itm)
-                vanilla_pool.append(itm)
+                if itm in progression_pool:
+                    progression_pool.remove(itm)
+                    vanilla_pool.append(itm)
+                elif itm in useful_pool:
+                    useful_pool.remove(itm)
+                    vanilla_pool.append(itm)
+                elif itm in filler_pool:
+                    filler_pool.remove(itm)
+                    vanilla_pool.append(itm)
 
     if not world.options.treasuresanity_in_silent_realms:
         for loc, data in LOCATION_TABLE.items():


### PR DESCRIPTION
## What is this fixing or adding?
Sends hint info to the archipelago server when the player reads a hint in-game.

## How was this tested?
I generated a seed and verified that hints were sent at the right time and with the right info (Gossip stones on reading the stone, song hints on receiving the song if direct hints are on, Fi hints at the start). Note this only works with location hints, since it requires scouting locations (which is only possible in your own world).