### PR TITLE
Hacky logic export

### DIFF
--- a/worlds/ss/Macros.py
+++ b/worlds/ss/Macros.py
@@ -49,14 +49,14 @@ def has_hook_beetle(state: CollectionState, player: int) -> bool:
 
 def has_quick_beetle(state: CollectionState, player: int) -> bool:
     return (
-        (state.has("Progressive Beetle", player, 3) and state._ss_option_gondo_upgrades(player))
-        or (can_upgrade_to_quick_beetle(state, player) and not state._ss_option_gondo_upgrades(player))
+        (state.has("Progressive Beetle", player, 3) & state._ss_option_gondo_upgrades(player))
+        | (can_upgrade_to_quick_beetle(state, player) & ~state._ss_option_gondo_upgrades(player))
     )
 
 def has_tough_beetle(state: CollectionState, player: int) -> bool:
     return (
-        (state.has("Progressive Beetle", player, 4) and state._ss_option_gondo_upgrades(player))
-        or (can_upgrade_to_tough_beetle(state, player) and not state._ss_option_gondo_upgrades(player))
+        (state.has("Progressive Beetle", player, 4) & state._ss_option_gondo_upgrades(player))
+        | (can_upgrade_to_tough_beetle(state, player) & ~state._ss_option_gondo_upgrades(player))
     )
 
 def has_bow(state: CollectionState, player: int) -> bool:
@@ -114,28 +114,28 @@ def has_three_extra_wallets(state: CollectionState, player: int) -> bool:
 def has_song_of_the_hero(state: CollectionState, player: int) -> bool:
     return (
         state.has("Faron Song of the Hero Part", player)
-        and state.has("Eldin Song of the Hero Part", player)
-        and state.has("Lanayru Song of the Hero Part", player)
+        & state.has("Eldin Song of the Hero Part", player)
+        & state.has("Lanayru Song of the Hero Part", player)
     )
 
 
 def has_bottle(state: CollectionState, player: int) -> bool:
-    return has_pouch(state, player) and state.has("Empty Bottle", player)
+    return has_pouch(state, player) & state.has("Empty Bottle", player)
 
 
 def has_completed_triforce(state: CollectionState, player: int) -> bool:
     return (
         state.has("Triforce of Courage", player)
-        and state.has("Triforce of Power", player)
-        and state.has("Triforce of Wisdom", player)
+        & state.has("Triforce of Power", player)
+        & state.has("Triforce of Wisdom", player)
     )
 
 
 # Misc
 def upgraded_skyward_strike(state: CollectionState, player: int) -> bool:
-    return has_true_master_sword(state, player) or (
+    return has_true_master_sword(state, player) | (
         state._ss_option_upgraded_skyward_strike(player)
-        and has_goddess_sword(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -146,70 +146,70 @@ def unlocked_endurance_potion(state: CollectionState, player: int) -> bool:
 def damaging_item(state: CollectionState, player: int) -> bool:
     return (
         has_practice_sword(state, player)
-        or has_bow(state, player)
-        or state.has("Bomb Bag", player)
+        | has_bow(state, player)
+        | state.has("Bomb Bag", player)
     )
 
 
 def projectile_item(state: CollectionState, player: int) -> bool:
     return (
         has_slingshot(state, player)
-        or has_beetle(state, player)
-        or has_bow(state, player)
+        | has_beetle(state, player)
+        | has_bow(state, player)
     )
 
 
 def distance_activator(state: CollectionState, player: int) -> bool:
-    return projectile_item(state, player) or state.has("Clawshots", player)
+    return projectile_item(state, player) | state.has("Clawshots", player)
 
 
 def can_cut_trees(state: CollectionState, player: int) -> bool:
-    return has_practice_sword(state, player) or state.has("Bomb Bag", player)
+    return has_practice_sword(state, player) | state.has("Bomb Bag", player)
 
 
 def can_unlock_combination_lock(state: CollectionState, player: int) -> bool:
     return (
         has_practice_sword(state, player)
-        or has_bow(state, player)
-        or state.has("Whip", player)
-        or state.has("Clawshots", player)
+        | has_bow(state, player)
+        | state.has("Whip", player)
+        | state.has("Clawshots", player)
     )
 
 
 def can_hit_timeshift_stone(state: CollectionState, player: int) -> bool:
     return (
         distance_activator(state, player)
-        or has_practice_sword(state, player)
-        or state.has("Whip", player)
-        or state.has("Bomb Bag", player)
+        | has_practice_sword(state, player)
+        | state.has("Whip", player)
+        | state.has("Bomb Bag", player)
     )
 
 def can_upgrade_to_quick_beetle(state: CollectionState, player: int) -> bool:
     return(
         has_hook_beetle(state, player)
-        and can_access_deep_woods(state, player) # Larvae farming
-        and (
+        & can_access_deep_woods(state, player) # Larvae farming
+        & (
             lanayru_mine_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming_near_main_node(state, player)
-            or pirate_stronghold_ancient_flower_farming(state, player)
-            or lanayru_gorge_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming_near_main_node(state, player)
+            | pirate_stronghold_ancient_flower_farming(state, player)
+            | lanayru_gorge_ancient_flower_farming(state, player)
         ) # Ancient flower farming
-        and clean_cut_minigame(state, player) # Gold Skull farming
+        & clean_cut_minigame(state, player) # Gold Skull farming
     )
 
 def can_upgrade_to_tough_beetle(state: CollectionState, player: int) -> bool:
     return(
         can_upgrade_to_quick_beetle(state, player)
-        and can_reach_most_of_faron_woods(state, player) # Amber relic farming
-        and (
+        & can_reach_most_of_faron_woods(state, player) # Amber relic farming
+        & (
             lanayru_mine_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming_near_main_node(state, player)
-            or pirate_stronghold_ancient_flower_farming(state, player)
-            or lanayru_gorge_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming_near_main_node(state, player)
+            | pirate_stronghold_ancient_flower_farming(state, player)
+            | lanayru_gorge_ancient_flower_farming(state, player)
         ) # Ancient flower farming
-        and clean_cut_minigame(state, player) # Plume/Blue feather farming
+        & clean_cut_minigame(state, player) # Plume/Blue feather farming
     )
 
 
@@ -225,15 +225,15 @@ def can_defeat_moblins(state: CollectionState, player: int) -> bool:
 def can_defeat_keeses(state: CollectionState, player: int) -> bool:
     return (
         damaging_item(state, player)
-        or has_slingshot(state, player)
-        or has_beetle(state, player)
-        or state.has("Whip", player)
-        or state.has("Clawshots", player)
+        | has_slingshot(state, player)
+        | has_beetle(state, player)
+        | state.has("Whip", player)
+        | state.has("Clawshots", player)
     )
 
 
 def can_defeat_lezalfos(state: CollectionState, player: int) -> bool:
-    return has_practice_sword(state, player) or state.has("Bomb Bag", player)
+    return has_practice_sword(state, player) | state.has("Bomb Bag", player)
 
 
 def can_defeat_ampilus(state: CollectionState, player: int) -> bool:
@@ -241,19 +241,19 @@ def can_defeat_ampilus(state: CollectionState, player: int) -> bool:
 
 
 def can_defeat_moldarachs(state: CollectionState, player: int) -> bool:
-    return state.has("Gust Bellows", player) and has_practice_sword(state, player)
+    return state.has("Gust Bellows", player) & has_practice_sword(state, player)
 
 
 def can_defeat_armos(state: CollectionState, player: int) -> bool:
-    return state.has("Gust Bellows", player) and has_practice_sword(state, player)
+    return state.has("Gust Bellows", player) & has_practice_sword(state, player)
 
 
 def can_defeat_beamos(state: CollectionState, player: int) -> bool:
-    return has_practice_sword(state, player) or has_bow(state, player)
+    return has_practice_sword(state, player) | has_bow(state, player)
 
 
 def can_defeat_cursed_bokoblins(state: CollectionState, player: int) -> bool:
-    return has_practice_sword(state, player) or state.has("Bomb Bag", player)
+    return has_practice_sword(state, player) | state.has("Bomb Bag", player)
 
 
 def can_defeat_stalfos(state: CollectionState, player: int) -> bool:
@@ -276,11 +276,11 @@ def can_obtain_5_loose_crystals(state: CollectionState, player: int) -> bool:
 def can_obtain_10_loose_crystals(state: CollectionState, player: int) -> bool:
     return (
         can_access_central_skyloft(state, player)
-        and can_access_sky(state, player)
-        and (
+        & can_access_sky(state, player)
+        & (
             can_cut_trees(state, player)  # 2 crystals past waterfall cave
-            or state.has("Clawshots", player)  # Zelda's room, atop waterfall
-            or has_beetle(state, player)
+            | state.has("Clawshots", player)  # Zelda's room, atop waterfall
+            | has_beetle(state, player)
         )  # Sparring hall, beedle's island
     )
 
@@ -288,15 +288,15 @@ def can_obtain_10_loose_crystals(state: CollectionState, player: int) -> bool:
 def can_obtain_15_loose_crystals(state: CollectionState, player: int) -> bool:
     return (
         can_access_central_skyloft(state, player)
-        and can_access_sky(state, player)
-        and (can_cut_trees(state, player) or has_beetle(state, player))
-        and state.has("Clawshots", player)
-        and has_beetle(state, player)
+        & can_access_sky(state, player)
+        & (can_cut_trees(state, player) | has_beetle(state, player))
+        & state.has("Clawshots", player)
+        & has_beetle(state, player)
     )
 
 
 def five_gratitude_crystals(state: CollectionState, player: int) -> bool:
-    return can_obtain_5_loose_crystals(state, player) or state.has(
+    return can_obtain_5_loose_crystals(state, player) | state.has(
         "Gratitude Crystal Pack", player, 1
     )
 
@@ -304,11 +304,11 @@ def five_gratitude_crystals(state: CollectionState, player: int) -> bool:
 def ten_gratitude_crystals(state: CollectionState, player: int) -> bool:
     return (
         can_obtain_10_loose_crystals(state, player)
-        or (
+        | (
             can_obtain_5_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 1)
+            & state.has("Gratitude Crystal Pack", player, 1)
         )
-        or state.has("Gratitude Crystal Pack", player)
+        | state.has("Gratitude Crystal Pack", player)
     )
 
 
@@ -316,17 +316,17 @@ def thirty_gratitude_crystals(state: CollectionState, player: int) -> bool:
     return (
         (
             can_obtain_15_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 3)
+            & state.has("Gratitude Crystal Pack", player, 3)
         )
-        or (
+        | (
             can_obtain_10_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 4)
+            & state.has("Gratitude Crystal Pack", player, 4)
         )
-        or (
+        | (
             can_obtain_5_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 5)
+            & state.has("Gratitude Crystal Pack", player, 5)
         )
-        or state.has("Gratitude Crystal Pack", player, 6)
+        | state.has("Gratitude Crystal Pack", player, 6)
     )
 
 
@@ -334,17 +334,17 @@ def forty_gratitude_crystals(state: CollectionState, player: int) -> bool:
     return (
         (
             can_obtain_15_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 5)
+            & state.has("Gratitude Crystal Pack", player, 5)
         )
-        or (
+        | (
             can_obtain_10_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 6)
+            & state.has("Gratitude Crystal Pack", player, 6)
         )
-        or (
+        | (
             can_obtain_5_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 7)
+            & state.has("Gratitude Crystal Pack", player, 7)
         )
-        or state.has("Gratitude Crystal Pack", player, 8)
+        | state.has("Gratitude Crystal Pack", player, 8)
     )
 
 
@@ -352,17 +352,17 @@ def fifty_gratitude_crystals(state: CollectionState, player: int) -> bool:
     return (
         (
             can_obtain_15_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 7)
+            & state.has("Gratitude Crystal Pack", player, 7)
         )
-        or (
+        | (
             can_obtain_10_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 8)
+            & state.has("Gratitude Crystal Pack", player, 8)
         )
-        or (
+        | (
             can_obtain_5_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 9)
+            & state.has("Gratitude Crystal Pack", player, 9)
         )
-        or state.has("Gratitude Crystal Pack", player, 10)
+        | state.has("Gratitude Crystal Pack", player, 10)
     )
 
 
@@ -370,21 +370,21 @@ def seventy_gratitude_crystals(state: CollectionState, player: int) -> bool:
     return (
         (
             can_obtain_15_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 11)
+            & state.has("Gratitude Crystal Pack", player, 11)
         )
-        or (
+        | (
             can_obtain_10_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 12)
+            & state.has("Gratitude Crystal Pack", player, 12)
         )
-        or (
+        | (
             can_obtain_5_loose_crystals(state, player)
-            and state.has("Gratitude Crystal Pack", player, 13)
+            & state.has("Gratitude Crystal Pack", player, 13)
         )
     )
 
 
 def eighty_gratitude_crystals(state: CollectionState, player: int) -> bool:
-    return can_obtain_15_loose_crystals(state, player) and state.has(
+    return can_obtain_15_loose_crystals(state, player) & state.has(
         "Gratitude Crystal Pack", player, 13
     )
 
@@ -399,63 +399,63 @@ def can_afford_300_rupees(state: CollectionState, player: int) -> bool:
 
 
 def can_afford_600_rupees(state: CollectionState, player: int) -> bool:
-    return can_high_rupee_farm(state, player) and (
-        has_big_wallet(state, player) or has_one_extra_wallet(state, player)
+    return can_high_rupee_farm(state, player) & (
+        has_big_wallet(state, player) | has_one_extra_wallet(state, player)
     )
 
 
 def can_afford_800_rupees(state: CollectionState, player: int) -> bool:
-    return can_high_rupee_farm(state, player) and (
+    return can_high_rupee_farm(state, player) & (
         has_big_wallet(state, player)
-        or has_two_extra_wallets(state, player)
-        or (has_medium_wallet(state, player) and has_one_extra_wallet(state, player))
+        | has_two_extra_wallets(state, player)
+        | (has_medium_wallet(state, player) & has_one_extra_wallet(state, player))
     )
 
 
 def can_afford_1000_rupees(state: CollectionState, player: int) -> bool:
-    return can_high_rupee_farm(state, player) and (
+    return can_high_rupee_farm(state, player) & (
         has_big_wallet(state, player)
-        or has_three_extra_wallets(state, player)
-        or (has_medium_wallet(state, player) and has_two_extra_wallets(state, player))
+        | has_three_extra_wallets(state, player)
+        | (has_medium_wallet(state, player) & has_two_extra_wallets(state, player))
     )
 
 
 def can_afford_1200_rupees(state: CollectionState, player: int) -> bool:
-    return can_high_rupee_farm(state, player) and (
+    return can_high_rupee_farm(state, player) & (
         has_giant_wallet(state, player)
-        or has_three_extra_wallets(state, player)
-        or (has_big_wallet(state, player) and has_one_extra_wallet(state, player))
-        or (has_medium_wallet(state, player) and has_three_extra_wallets(state, player))
+        | has_three_extra_wallets(state, player)
+        | (has_big_wallet(state, player) & has_one_extra_wallet(state, player))
+        | (has_medium_wallet(state, player) & has_three_extra_wallets(state, player))
     )
 
 
 def can_afford_1600_rupees(state: CollectionState, player: int) -> bool:
-    return can_high_rupee_farm(state, player) and (
+    return can_high_rupee_farm(state, player) & (
         has_giant_wallet(state, player)
-        or (has_big_wallet(state, player) and has_two_extra_wallets(state, player))
+        | (has_big_wallet(state, player) & has_two_extra_wallets(state, player))
     )
 
 
 def can_medium_rupee_farm(state: CollectionState, player: int) -> bool:
     return (
-        clean_cut_minigame(state, player) and can_access_skyloft_village(state, player)
-    ) or can_high_rupee_farm(state, player)
+        clean_cut_minigame(state, player) & can_access_skyloft_village(state, player)
+    ) | can_high_rupee_farm(state, player)
 
 
 def can_high_rupee_farm(state: CollectionState, player: int) -> bool:
-    return fun_fun_minigame(state, player) or thrill_digger_minigame(state, player)
+    return fun_fun_minigame(state, player) | thrill_digger_minigame(state, player)
 
 
 def clean_cut_minigame(state: CollectionState, player: int) -> bool:
-    return can_access_sky(state, player) and has_practice_sword(state, player)
+    return can_access_sky(state, player) & has_practice_sword(state, player)
 
 
 def fun_fun_minigame(state: CollectionState, player: int) -> bool:
-    return can_access_sky(state, player) and can_retrieve_party_wheel(state, player)
+    return can_access_sky(state, player) & can_retrieve_party_wheel(state, player)
 
 
 def thrill_digger_minigame(state: CollectionState, player: int) -> bool:
-    return can_reach_second_part_of_eldin_volcano(state, player) and has_digging_mitts(
+    return can_reach_second_part_of_eldin_volcano(state, player) & has_digging_mitts(
         state, player
     )
 
@@ -477,16 +477,16 @@ def can_access_skyloft_village(state: CollectionState, player: int) -> bool:
 def can_reach_dungeon_entrance_on_skyloft(state: CollectionState, player: int) -> bool:
     return (
         can_access_central_skyloft(state, player)
-        and state.has("Stone of Trials", player)
-        and state.has("Clawshots", player)
+        & state.has("Stone of Trials", player)
+        & state.has("Clawshots", player)
     )
 
 
 def can_open_trial_gate_on_skyloft(state: CollectionState, player: int) -> bool:
     return (
         can_access_central_skyloft(state, player)
-        and has_song_of_the_hero(state, player)
-        and state.has("Goddess's Harp", player)
+        & has_song_of_the_hero(state, player)
+        & state.has("Goddess's Harp", player)
     )
 
 
@@ -503,14 +503,14 @@ def can_save_orielle(state: CollectionState, player: int) -> bool:
 def can_access_thunderhead(state: CollectionState, player: int) -> bool:
     return (
         state._ss_option_thunderhead_ballad(player)
-        and state.has("Ballad of the Goddess", player)
-    ) or state._ss_option_thunderhead_open(player)
+        & state.has("Ballad of the Goddess", player)
+    ) | state._ss_option_thunderhead_open(player)
 
 
 ### Faron
 # Sealed Grounds
 def can_access_sealed_grounds(state: CollectionState, player: int) -> bool:
-    return can_access_sky(state, player) and state.has("Emerald Tablet", player)
+    return can_access_sky(state, player) & state.has("Emerald Tablet", player)
 
 
 def can_reach_sealed_temple(state: CollectionState, player: int) -> bool:
@@ -525,15 +525,15 @@ def can_raise_gate_of_time(state: CollectionState, player: int) -> bool:
 def can_reach_past(state: CollectionState, player: int) -> bool:
     return (
         can_reach_sealed_temple(state, player)
-        and can_raise_gate_of_time(state, player)
-        and state._ss_sword_requirement_met(player)
-        and (state._ss_can_beat_required_dungeons(player) or state._ss_option_unrequired_dungeons(player))
+        & can_raise_gate_of_time(state, player)
+        & state._ss_sword_requirement_met(player)
+        & (state._ss_can_beat_required_dungeons(player) | state._ss_option_unrequired_dungeons(player))
     )
 
 
 def can_access_hylias_realm(state: CollectionState, player: int) -> bool:
-    return can_reach_past(state, player) and (
-        state._ss_option_no_triforce(player) or has_completed_triforce(state, player)
+    return can_reach_past(state, player) & (
+        state._ss_option_no_triforce(player) | has_completed_triforce(state, player)
     )
 
 
@@ -549,9 +549,9 @@ def can_access_faron_woods(state: CollectionState, player: int) -> bool:
 def can_reach_most_of_faron_woods(state: CollectionState, player: int) -> bool:
     return (
         can_access_faron_woods(state, player)
-        and (
+        & (
             can_cut_trees(state, player)
-            or state.has("Clawshots", player)
+            | state.has("Clawshots", player)
         )
     )
 
@@ -560,36 +560,36 @@ def can_reach_oolo(state: CollectionState, player: int) -> bool:
     return (
         (
             can_access_faron_woods(state, player)
-            or can_access_flooded_faron_woods(state, player)
+            | can_access_flooded_faron_woods(state, player)
         )
-        and can_reach_most_of_faron_woods(state, player)
-        and state.has("Bomb Bag", player)
+        & can_reach_most_of_faron_woods(state, player)
+        & state.has("Bomb Bag", player)
     )
 
 
 def can_reach_great_tree(state: CollectionState, player: int) -> bool:
-    return can_reach_most_of_faron_woods(state, player) and state.has(
+    return can_reach_most_of_faron_woods(state, player) & state.has(
         "Water Dragon's Scale", player
     )
 
 
 def can_reach_top_of_great_tree(state: CollectionState, player: int) -> bool:
     return (
-        can_reach_most_of_faron_woods(state, player) and state.has("Clawshots", player)
-    ) or (can_reach_great_tree(state, player) and state.has("Gust Bellows", player))
+        can_reach_most_of_faron_woods(state, player) & state.has("Clawshots", player)
+    ) | (can_reach_great_tree(state, player) & state.has("Gust Bellows", player))
 
 
 def can_talk_to_yerbal(state: CollectionState, player: int) -> bool:
-    return can_reach_top_of_great_tree(state, player) and (
-        has_slingshot(state, player) or has_beetle(state, player)
+    return can_reach_top_of_great_tree(state, player) & (
+        has_slingshot(state, player) | has_beetle(state, player)
     )
 
 
 def can_open_trial_gate_in_faron_woods(state: CollectionState, player: int) -> bool:
     return (
         can_reach_most_of_faron_woods(state, player)
-        and state.has("Farore's Courage", player)
-        and state.has("Goddess's Harp", player)
+        & state.has("Farore's Courage", player)
+        & state.has("Goddess's Harp", player)
     )
 
 
@@ -598,17 +598,17 @@ def goddess_cube_on_east_great_tree_with_clawshot_target(
 ) -> bool:
     return (
         can_reach_most_of_faron_woods(state, player)
-        and (
-            state.has("Clawshots", player) or can_reach_top_of_great_tree(state, player)
+        & (
+            state.has("Clawshots", player) | can_reach_top_of_great_tree(state, player)
         )
-        and has_goddess_sword(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_on_east_great_tree_with_rope(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_top_of_great_tree(state, player) and has_goddess_sword(
+    return can_reach_top_of_great_tree(state, player) & has_goddess_sword(
         state, player
     )
 
@@ -616,42 +616,42 @@ def goddess_cube_on_east_great_tree_with_rope(
 def goddess_cube_on_west_great_tree_near_exit(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_top_of_great_tree(state, player) and has_goddess_sword(
+    return can_reach_top_of_great_tree(state, player) & has_goddess_sword(
         state, player
     )
 
 
 # Deep Woods
 def can_access_deep_woods(state: CollectionState, player: int) -> bool:
-    return can_reach_most_of_faron_woods(state, player) and (
-        distance_activator(state, player) or state.has("Bomb Bag", player)
+    return can_reach_most_of_faron_woods(state, player) & (
+        distance_activator(state, player) | state.has("Bomb Bag", player)
     )
 
 
 def can_reach_deep_woods_after_beehive(state: CollectionState, player: int) -> bool:
-    return can_access_deep_woods(state, player) and (
+    return can_access_deep_woods(state, player) & (
         distance_activator(state, player)
-        or has_goddess_sword(state, player)
-        or state.has("Bomb Bag", player)
+        | has_goddess_sword(state, player)
+        | state.has("Bomb Bag", player)
     )
 
 
 def can_reach_dungeon_entrance_in_deep_woods(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_deep_woods_after_beehive(state, player) and distance_activator(
+    return can_reach_deep_woods_after_beehive(state, player) & distance_activator(
         state, player
     )
 
 
 def initial_goddess_cube(state: CollectionState, player: int) -> bool:
-    return can_reach_deep_woods_after_beehive(state, player) and has_goddess_sword(
+    return can_reach_deep_woods_after_beehive(state, player) & has_goddess_sword(
         state, player
     )
 
 
 def goddess_cube_in_deep_woods(state: CollectionState, player: int) -> bool:
-    return can_reach_deep_woods_after_beehive(state, player) and has_goddess_sword(
+    return can_reach_deep_woods_after_beehive(state, player) & has_goddess_sword(
         state, player
     )
 
@@ -659,8 +659,8 @@ def goddess_cube_in_deep_woods(state: CollectionState, player: int) -> bool:
 def goddess_cube_on_top_on_skyview(state: CollectionState, player: int) -> bool:
     return (
         can_reach_dungeon_entrance_in_deep_woods(state, player)
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -668,14 +668,14 @@ def goddess_cube_on_top_on_skyview(state: CollectionState, player: int) -> bool:
 def can_access_lake_floria(state: CollectionState, player: int) -> bool:
     return (
         can_reach_most_of_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player)
-        and (
-            (can_talk_to_yerbal(state, player) and has_goddess_sword(state, player))
-            or (
+        & state.has("Water Dragon's Scale", player)
+        & (
+            (can_talk_to_yerbal(state, player) & has_goddess_sword(state, player))
+            | (
                 can_talk_to_yerbal(state, player)
-                and state._ss_option_lake_floria_yerbal(player)
+                & state._ss_option_lake_floria_yerbal(player)
             )
-            or state._ss_option_lake_floria_open(player)
+            | state._ss_option_lake_floria_open(player)
         )
     )
 
@@ -687,20 +687,20 @@ def can_reach_floria_waterfall(state: CollectionState, player: int) -> bool:
 def can_reach_dungeon_entrance_in_lake_floria(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_floria_waterfall(state, player) and state.has(
+    return can_reach_floria_waterfall(state, player) & state.has(
         "Water Dragon's Scale", player
     )
 
 
 def goddess_cube_in_lake_floria(state: CollectionState, player: int) -> bool:
-    return can_access_lake_floria(state, player) and has_goddess_sword(state, player)
+    return can_access_lake_floria(state, player) & has_goddess_sword(state, player)
 
 
 def goddess_cube_in_floria_waterfall(state: CollectionState, player: int) -> bool:
     return (
         can_reach_floria_waterfall(state, player)
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -712,54 +712,54 @@ def can_access_flooded_faron_woods(state: CollectionState, player: int) -> bool:
 ### Eldin
 # Eldin Volcano
 def can_access_eldin_volcano(state: CollectionState, player: int) -> bool:
-    return can_access_sky(state, player) and state.has("Ruby Tablet", player)
+    return can_access_sky(state, player) & state.has("Ruby Tablet", player)
 
 
 def can_reach_second_part_of_eldin_volcano(state: CollectionState, player: int) -> bool:
-    return can_access_eldin_volcano(state, player) and (
+    return can_access_eldin_volcano(state, player) & (
         can_reach_second_part_of_mogma_turf(state, player)
-        or (state.has("Bomb Bag", player) or has_hook_beetle(state, player))
+        | (state.has("Bomb Bag", player) | has_hook_beetle(state, player))
     )
 
 
 def can_survive_eldin_hot_cave(state: CollectionState, player: int) -> bool:
     return state.has(
         "Fireshield Earrings", player
-    ) or state._ss_option_damage_multiplier_under_12(player)
+    ) | state._ss_option_damage_multiplier_under_12(player)
 
 
 def can_open_trial_gate_in_eldin_volcano(state: CollectionState, player: int) -> bool:
     return (
         can_reach_second_part_of_eldin_volcano(state, player)
-        and state.has("Din's Power", player)
-        and state.has("Goddess's Harp", player)
+        & state.has("Din's Power", player)
+        & state.has("Goddess's Harp", player)
     )
 
 
 def can_reach_dungeon_entrance_in_eldin_volcano(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_second_part_of_eldin_volcano(state, player) and state.has(
+    return can_reach_second_part_of_eldin_volcano(state, player) & state.has(
         "Key Piece", player, 5
     )
 
 
 def goddess_cube_at_eldin_entrance(state: CollectionState, player: int) -> bool:
-    return can_access_eldin_volcano(state, player) and has_goddess_sword(state, player)
+    return can_access_eldin_volcano(state, player) & has_goddess_sword(state, player)
 
 
 def goddess_cube_near_mogma_turf_entrance(state: CollectionState, player: int) -> bool:
     return (
         can_access_eldin_volcano(state, player)
-        or (can_access_bokoblin_base(state, player) and has_mogma_mitts(state, player))
-    ) and has_goddess_sword(state, player)
+        | (can_access_bokoblin_base(state, player) & has_mogma_mitts(state, player))
+    ) & has_goddess_sword(state, player)
 
 
 def goddess_cube_on_sand_slide(state: CollectionState, player: int) -> bool:
     return (
         can_reach_second_part_of_eldin_volcano(state, player)
-        and can_survive_eldin_hot_cave(state, player)
-        and has_goddess_sword(state, player)
+        & can_survive_eldin_hot_cave(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -768,19 +768,19 @@ def goddess_cube_east_of_earth_temple_entrance(
 ) -> bool:
     return (
         can_reach_second_part_of_eldin_volcano(state, player)
-        or (
+        | (
             can_access_bokoblin_base(state, player)
-            and has_mogma_mitts(state, player)
-            and state.has("Clawshots", player)
-            and (
+            & has_mogma_mitts(state, player)
+            & state.has("Clawshots", player)
+            & (
                 state.has("Bomb Bag", player)
-                or (
+                | (
                     can_bypass_boko_base_watchtower(state, player)
-                    and state.has("Whip", player)
+                    & state.has("Whip", player)
                 )
             )
         )
-    ) and has_goddess_sword(state, player)
+    ) & has_goddess_sword(state, player)
 
 
 def goddess_cube_west_of_earth_temple_entrance(
@@ -789,19 +789,19 @@ def goddess_cube_west_of_earth_temple_entrance(
     return (
         (
             can_reach_second_part_of_eldin_volcano(state, player)
-            and has_digging_mitts(state, player)
+            & has_digging_mitts(state, player)
         )
-        or (
+        | (
             can_access_bokoblin_base(state, player)
-            and has_mogma_mitts(state, player)
-            and state.has("Clawshots", player)
-            and (
+            & has_mogma_mitts(state, player)
+            & state.has("Clawshots", player)
+            & (
                 state.has("Bomb Bag", player)
-                or can_bypass_boko_base_watchtower(state, player)
-                and state.has("Whip", player)
+                | can_bypass_boko_base_watchtower(state, player)
+                & state.has("Whip", player)
             )
         )
-    ) and has_goddess_sword(state, player)
+    ) & has_goddess_sword(state, player)
 
 
 # Mogma Turf
@@ -810,26 +810,26 @@ def can_access_mogma_turf(state: CollectionState, player: int) -> bool:
 
 
 def can_reach_second_part_of_mogma_turf(state: CollectionState, player: int) -> bool:
-    return can_access_mogma_turf(state, player) and has_digging_mitts(state, player)
+    return can_access_mogma_turf(state, player) & has_digging_mitts(state, player)
 
 
 def goddess_cube_in_mogma_turf(state: CollectionState, player: int) -> bool:
-    return can_access_mogma_turf(state, player) and has_goddess_sword(state, player)
+    return can_access_mogma_turf(state, player) & has_goddess_sword(state, player)
 
 
 # Volcano Summit
 def can_access_volcano_summit(state: CollectionState, player: int) -> bool:
-    return can_reach_second_part_of_eldin_volcano(state, player) and state.has(
+    return can_reach_second_part_of_eldin_volcano(state, player) & state.has(
         "Fireshield Earrings", player
     )
 
 
 def can_pass_volcano_summit_first_frog(state: CollectionState, player: int) -> bool:
-    return can_access_volcano_summit(state, player) and has_bottle(state, player)
+    return can_access_volcano_summit(state, player) & has_bottle(state, player)
 
 
 def can_pass_volcano_summit_second_frog(state: CollectionState, player: int) -> bool:
-    return can_pass_volcano_summit_first_frog(state, player) and state.has(
+    return can_pass_volcano_summit_first_frog(state, player) & state.has(
         "Clawshots", player
     )
 
@@ -843,22 +843,22 @@ def can_reach_dungeon_entrance_in_volcano_summit(
 def goddess_cube_inside_volcano_summit(state: CollectionState, player: int) -> bool:
     return (
         can_access_volcano_summit(state, player)
-        and (
+        & (
             upgraded_skyward_strike(state, player)
-            or (
+            | (
                 can_access_bokoblin_base(state, player)
-                and has_mogma_mitts(state, player)
-                and state.has("Clawshots", player)
-                and state.has("Bomb Bag", player)
-                and state.has("Fireshield Earrings", player)
+                & has_mogma_mitts(state, player)
+                & state.has("Clawshots", player)
+                & state.has("Bomb Bag", player)
+                & state.has("Fireshield Earrings", player)
             )
         )
-        and has_goddess_sword(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_in_summit_waterfall(state: CollectionState, player: int) -> bool:
-    return can_access_volcano_summit(state, player) and has_goddess_sword(state, player)
+    return can_access_volcano_summit(state, player) & has_goddess_sword(state, player)
 
 
 def goddess_cube_near_fire_sanctuary_entrance(
@@ -866,8 +866,8 @@ def goddess_cube_near_fire_sanctuary_entrance(
 ) -> bool:
     return (
         can_pass_volcano_summit_second_frog(state, player)
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -879,8 +879,8 @@ def can_access_bokoblin_base(state: CollectionState, player: int) -> bool:
 def can_bypass_boko_base_watchtower(state: CollectionState, player: int) -> bool:
     return (
         state.has("Bomb Bag", player)
-        or has_slingshot(state, player)
-        or has_bow(state, player)
+        | has_slingshot(state, player)
+        | has_bow(state, player)
     )
 
 
@@ -895,76 +895,76 @@ def can_access_lanayru_mine(state: CollectionState, player: int) -> bool:
 def can_reach_second_part_of_lanayru_mine(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_mine(state, player)
-        and can_hit_timeshift_stone(state, player)
-        and (
+        & can_hit_timeshift_stone(state, player)
+        & (
             state.has("Bomb Bag", player)
-            or has_hook_beetle(state, player)
-            or False  # (unlocked_endurance_potion(state, player) and has_bottle(state, player))
+            | has_hook_beetle(state, player)
+            | False  # (unlocked_endurance_potion(state, player) & has_bottle(state, player))
         )  # Line above is recursive, AP doesn't like that :c
     )
 
 
 def goddess_cube_at_lanayru_mine_entrance(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_mine(state, player) and has_goddess_sword(state, player)
+    return can_access_lanayru_mine(state, player) & has_goddess_sword(state, player)
 
 
 # Lanayru Desert
 def can_access_lanayru_desert(state: CollectionState, player: int) -> bool:
-    return can_reach_second_part_of_lanayru_mine(state, player) or (
-        can_access_lanayru_mine(state, player) and state.has("Clawshots", player)
+    return can_reach_second_part_of_lanayru_mine(state, player) | (
+        can_access_lanayru_mine(state, player) & state.has("Clawshots", player)
     )
 
 
 def can_retrieve_party_wheel(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_desert(state, player)
-        and state.has("Scrapper", player)
-        and state.has("Bomb Bag", player)
+        & state.has("Scrapper", player)
+        & state.has("Bomb Bag", player)
     )
 
 
 def can_reach_temple_of_time(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_desert(state, player) and (
-        state.has("Clawshots", player) or has_hook_beetle(state, player)
+    return can_access_lanayru_desert(state, player) & (
+        state.has("Clawshots", player) | has_hook_beetle(state, player)
     )
 
 
 def can_reach_second_part_of_lanayru_desert(
     state: CollectionState, player: int
 ) -> bool:
-    return can_access_lanayru_desert(state, player) and (
+    return can_access_lanayru_desert(state, player) & (
         state.has("Clawshots", player)
-        or can_reach_temple_of_time(state, player)
-        or state._ss_option_lmf_open(player)
+        | can_reach_temple_of_time(state, player)
+        | state._ss_option_lmf_open(player)
     )
 
 
 def can_activate_nodes(state: CollectionState, player: int) -> bool:
     return (
         can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player)
-        and has_practice_sword(state, player)
-        and can_defeat_ampilus(state, player)
-        and has_hook_beetle(state, player)
+        & state.has("Bomb Bag", player)
+        & has_practice_sword(state, player)
+        & can_defeat_ampilus(state, player)
+        & has_hook_beetle(state, player)
     )
 
 
 def can_raise_lmf(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_desert(state, player) and (
+    return can_access_lanayru_desert(state, player) & (
         state._ss_option_lmf_open(player)
-        or (
+        | (
             state._ss_option_lmf_main_node(player)
-            and can_reach_second_part_of_lanayru_desert(state, player)
+            & can_reach_second_part_of_lanayru_desert(state, player)
         )
-        or can_activate_nodes(state, player)
+        | can_activate_nodes(state, player)
     )
 
 
 def can_open_trial_gate_in_lanayru_desert(state: CollectionState, player: int) -> bool:
     return (
         can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Nayru's Wisdom", player)
-        and state.has("Goddess's Harp", player)
+        & state.has("Nayru's Wisdom", player)
+        & state.has("Goddess's Harp", player)
     )
 
 
@@ -977,33 +977,33 @@ def can_reach_dungeon_entrance_in_lanayru_desert(
 def goddess_cube_near_caged_robot(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_desert(state, player)
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_in_secret_passageway(state: CollectionState, player: int) -> bool:
     return (
         can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Bomb Bag", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & state.has("Bomb Bag", player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_in_sand_oasis(state: CollectionState, player: int) -> bool:
-    return can_reach_temple_of_time(state, player) and has_goddess_sword(state, player)
+    return can_reach_temple_of_time(state, player) & has_goddess_sword(state, player)
 
 
 def goddess_cube_at_ride_near_temple_of_time(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_temple_of_time(state, player) and has_goddess_sword(state, player)
+    return can_reach_temple_of_time(state, player) & has_goddess_sword(state, player)
 
 
 # Lanayru Caves
 def can_access_lanayru_caves(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_mine(state, player) and state.has("Clawshots", player)
+    return can_access_lanayru_mine(state, player) & state.has("Clawshots", player)
 
 
 # Lanayru Gorge
@@ -1014,8 +1014,8 @@ def can_access_lanayru_gorge(state: CollectionState, player: int) -> bool:
 def goddess_cube_in_lanayru_gorge(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_gorge(state, player)
-        and can_hit_timeshift_stone(state, player)
-        and has_goddess_sword(state, player)
+        & can_hit_timeshift_stone(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
@@ -1023,8 +1023,8 @@ def goddess_cube_in_lanayru_gorge(state: CollectionState, player: int) -> bool:
 def can_access_lanayru_sand_sea(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_caves(state, player)
-        and state.has("Lanayru Caves Small Key", player)
-        and state.has("Clawshots", player)
+        & state.has("Lanayru Caves Small Key", player)
+        & state.has("Clawshots", player)
     )
 
 
@@ -1033,53 +1033,53 @@ def can_reach_dungeon_entrance_in_lanayru_sand_sea(
 ) -> bool:
     return (
         can_access_lanayru_sand_sea(state, player)
-        and state.has("Sea Chart", player)
-        and has_practice_sword(state, player)
+        & state.has("Sea Chart", player)
+        & has_practice_sword(state, player)
     )
 
 
 def goddess_cube_in_ancient_harbour(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_sand_sea(state, player)
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_in_skippers_retreat(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_sand_sea(state, player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player))
-        and state.has("Clawshots", player)
-        and has_goddess_sword(state, player)
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player))
+        & state.has("Clawshots", player)
+        & has_goddess_sword(state, player)
     )
 
 
 def goddess_cube_in_pirate_stronghold(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_sand_sea(state, player)
-        and can_defeat_beamos(state, player)
-        and can_defeat_armos(state, player)
-        and has_goddess_sword(state, player)
+        & can_defeat_beamos(state, player)
+        & can_defeat_armos(state, player)
+        & has_goddess_sword(state, player)
     )
 
 
 # Ancient Flowers
 def lanayru_mine_ancient_flower_farming(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_mine(state, player) and can_hit_timeshift_stone(
+    return can_access_lanayru_mine(state, player) & can_hit_timeshift_stone(
         state, player
     )
 
 
 def lanayru_desert_ancient_flower_farming(state: CollectionState, player: int) -> bool:
-    return can_access_lanayru_desert(state, player) and state.has("Bomb Bag", player)
+    return can_access_lanayru_desert(state, player) & state.has("Bomb Bag", player)
 
 
 def lanayru_desert_ancient_flower_farming_near_main_node(
     state: CollectionState, player: int
 ) -> bool:
-    return can_reach_second_part_of_lanayru_desert(state, player) and (
-        has_hook_beetle(state, player) or state.has("Bomb Bag", player)
+    return can_reach_second_part_of_lanayru_desert(state, player) & (
+        has_hook_beetle(state, player) | state.has("Bomb Bag", player)
     )
 
 
@@ -1092,8 +1092,8 @@ def pirate_stronghold_ancient_flower_farming(
 def lanayru_gorge_ancient_flower_farming(state: CollectionState, player: int) -> bool:
     return (
         can_access_lanayru_gorge(state, player)
-        and state.has("Gust Bellows", player)
-        and can_hit_timeshift_stone(state, player)
+        & state.has("Gust Bellows", player)
+        & can_hit_timeshift_stone(state, player)
     )
 
 
@@ -1105,12 +1105,12 @@ def lanayru_gorge_ancient_flower_farming(state: CollectionState, player: int) ->
 def can_reach_SV_second_room(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Skyview", player)
-        and can_cut_trees(state, player)
-        and (
+        & can_cut_trees(state, player)
+        & (
             state.has("Water Dragon's Scale", player)  # Skyview 2
-            or state.has("Bomb Bag", player)  # Bomb the barricade
-            or (
-                distance_activator(state, player) and has_practice_sword(state, player)
+            | state.has("Bomb Bag", player)  # Bomb the barricade
+            | (
+                distance_activator(state, player) & has_practice_sword(state, player)
             )  # One eye room
         )
     )
@@ -1119,13 +1119,13 @@ def can_reach_SV_second_room(state: CollectionState, player: int) -> bool:
 def can_reach_SV_main_room(state: CollectionState, player: int) -> bool:
     return (
         can_reach_SV_second_room(state, player)
-        and state.has("Skyview Small Key", player)
-        and (
+        & state.has("Skyview Small Key", player)
+        & (
             distance_activator(state, player)
-            or has_goddess_sword(state, player)  # Only have to raise water level once
-            or state.has(
+            | has_goddess_sword(state, player)  # Only have to raise water level once
+            | state.has(
                 "Whip", player
-            )  # Whip and goddess sword can hit vines in left room
+            )  # Whip & goddess sword can hit vines in left room
         )
     )
 
@@ -1133,21 +1133,21 @@ def can_reach_SV_main_room(state: CollectionState, player: int) -> bool:
 def can_reach_SV_boss_door(state: CollectionState, player: int) -> bool:
     return (
         can_reach_SV_second_room(state, player)
-        and state.has("Skyview Small Key", player, 2)
-        and (
-            has_practice_sword(state, player) or state.has("Bomb Bag", player)
+        & state.has("Skyview Small Key", player, 2)
+        & (
+            has_practice_sword(state, player) | state.has("Bomb Bag", player)
         )  # Staldra fight
-        and (
+        & (
             has_goddess_sword(state, player)  # Hanging Skulltula
-            or has_beetle(state, player)  # Break web with beetle or bow
-            or has_bow(state, player)  # Knock away with skyward strike or bombs
-            or state.has("Water Dragon's Scale", player)  # Doesn't exist in skyview 2
-            or state.has("Bomb Bag", player)
+            | has_beetle(state, player)  # Break web with beetle | bow
+            | has_bow(state, player)  # Knock away with skyward strike | bombs
+            | state.has("Water Dragon's Scale", player)  # Doesn't exist in skyview 2
+            | state.has("Bomb Bag", player)
         )
-        and (
+        & (
             upgraded_skyward_strike(state, player)
-            or has_hook_beetle(state, player)
-            or has_bow(state, player)  # Archers in last room in skyview 2
+            | has_hook_beetle(state, player)
+            | has_bow(state, player)  # Archers in last room in skyview 2
         )
     )
 
@@ -1155,82 +1155,82 @@ def can_reach_SV_boss_door(state: CollectionState, player: int) -> bool:
 def can_beat_ghirahim_1(state: CollectionState, player: int) -> bool:
     return (
         can_reach_SV_boss_door(state, player)
-        and state.has("Skyview Boss Key", player)
-        and has_practice_sword(state, player)
+        & state.has("Skyview Boss Key", player)
+        & has_practice_sword(state, player)
     )
 
 
 def can_beat_SV(state: CollectionState, player: int) -> bool:
-    return can_beat_ghirahim_1(state, player) and has_goddess_sword(state, player)
+    return can_beat_ghirahim_1(state, player) & has_goddess_sword(state, player)
 
 
 def goddess_cube_in_skyview_spring(state: CollectionState, player: int) -> bool:
-    return can_beat_ghirahim_1(state, player) and has_goddess_sword(state, player)
+    return can_beat_ghirahim_1(state, player) & has_goddess_sword(state, player)
 
 
 # Earth Temple
 def can_lower_ET_drawbridge(state: CollectionState, player: int) -> bool:
-    return has_bow(state, player) or has_beetle(state, player)
+    return has_bow(state, player) | has_beetle(state, player)
 
 
 def can_dislodge_ET_boulder(state: CollectionState, player: int) -> bool:
     return (
         has_slingshot(state, player)
-        or has_bow(state, player)
-        or upgraded_skyward_strike(state, player)
-        or state.has("Clawshots", player)
-        or (has_beetle(state, player) and can_defeat_lezalfos(state, player))
+        | has_bow(state, player)
+        | upgraded_skyward_strike(state, player)
+        | state.has("Clawshots", player)
+        | (has_beetle(state, player) & can_defeat_lezalfos(state, player))
     )
 
 
 def can_reach_ET_main_room(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Earth Temple", player)
-        and can_lower_ET_drawbridge(state, player)
-        and can_dislodge_ET_boulder(state, player)
+        & can_lower_ET_drawbridge(state, player)
+        & can_dislodge_ET_boulder(state, player)
     )
 
 
 def can_pass_ET_boulder_section(state: CollectionState, player: int) -> bool:
     return (
         can_reach_ET_main_room(state, player)
-        and has_beetle(state, player)
-        and (has_hook_beetle(state, player) or state.has("Bomb Bag", player))
+        & has_beetle(state, player)
+        & (has_hook_beetle(state, player) | state.has("Bomb Bag", player))
     )
 
 
 def can_reach_ET_boss_door(state: CollectionState, player: int) -> bool:
-    return can_pass_ET_boulder_section(state, player) and (
+    return can_pass_ET_boulder_section(state, player) & (
         has_hook_beetle(state, player)
-        or (has_digging_mitts(state, player) and state.has("Bomb Bag", player))
+        | (has_digging_mitts(state, player) & state.has("Bomb Bag", player))
     )
 
 
 def can_beat_scaldera(state: CollectionState, player: int) -> bool:
     return (
         can_reach_ET_boss_door(state, player)
-        and state.has("Earth Temple Boss Key", player)
-        and state.has("Bomb Bag", player)
-        and has_practice_sword(state, player)
+        & state.has("Earth Temple Boss Key", player)
+        & state.has("Bomb Bag", player)
+        & has_practice_sword(state, player)
     )
 
 
 def can_beat_ET(state: CollectionState, player: int) -> bool:
-    return can_beat_scaldera(state, player) and has_goddess_sword(state, player)
+    return can_beat_scaldera(state, player) & has_goddess_sword(state, player)
 
 
 # Lanayru Mining Facility
 def can_reach_LMF_second_room(state: CollectionState, player: int) -> bool:
     return state.can_reach_region(
         "Lanayru Mining Facility", player
-    ) and has_hook_beetle(state, player)
+    ) & has_hook_beetle(state, player)
 
 
 def can_reach_LMF_key_locked_room_in_past(state: CollectionState, player: int) -> bool:
     return (
         can_reach_LMF_second_room(state, player)
-        and state.has("Lanayru Mining Facility Small Key", player)
-        and has_hook_beetle(state, player)
+        & state.has("Lanayru Mining Facility Small Key", player)
+        & has_hook_beetle(state, player)
     )
 
 
@@ -1241,20 +1241,20 @@ def can_reach_LMF_hub_room(state: CollectionState, player: int) -> bool:
 def can_reach_LMF_hub_room_west(state: CollectionState, player: int) -> bool:
     return (
         can_reach_LMF_second_room(state, player)
-        and state.has("Gust Bellows", player)
-        and can_defeat_beamos(state, player)
-        and can_defeat_armos(state, player)
-        and (
+        & state.has("Gust Bellows", player)
+        & can_defeat_beamos(state, player)
+        & can_defeat_armos(state, player)
+        & (
             has_goddess_sword(state, player)
-            or has_slingshot(state, player)
-            or has_bow(state, player)
-            or state.has("Whip", player)  # to hit timeshift stone
+            | has_slingshot(state, player)
+            | has_bow(state, player)
+            | state.has("Whip", player)  # to hit timeshift stone
         )
     )
 
 
 def can_reach_LMF_boss_door(state: CollectionState, player: int) -> bool:
-    return can_reach_LMF_hub_room_west(state, player) and state.has(
+    return can_reach_LMF_hub_room_west(state, player) & state.has(
         "Gust Bellows", player
     )
 
@@ -1262,12 +1262,12 @@ def can_reach_LMF_boss_door(state: CollectionState, player: int) -> bool:
 def can_pass_LMF_boss_key_room(state: CollectionState, player: int) -> bool:
     return (
         can_reach_LMF_boss_door(state, player)
-        and state.has("Gust Bellows", player)
-        and state.has("Bomb Bag", player)  # Bombs uncover statues
-        and can_defeat_beamos(state, player)
-        and can_defeat_armos(state, player)
-        and (
-            has_practice_sword(state, player) or distance_activator(state, player)
+        & state.has("Gust Bellows", player)
+        & state.has("Bomb Bag", player)  # Bombs uncover statues
+        & can_defeat_beamos(state, player)
+        & can_defeat_armos(state, player)
+        & (
+            has_practice_sword(state, player) | distance_activator(state, player)
         )  # Hit crystals
     )
 
@@ -1275,114 +1275,114 @@ def can_pass_LMF_boss_key_room(state: CollectionState, player: int) -> bool:
 def can_beat_moldarach(state: CollectionState, player: int) -> bool:
     return (
         can_reach_LMF_boss_door(state, player)
-        and state.has("Lanayru Mining Facility Boss Key", player)
-        and can_defeat_moldarachs(state, player)
+        & state.has("Lanayru Mining Facility Boss Key", player)
+        & can_defeat_moldarachs(state, player)
     )
 
 
 def can_beat_LMF(state: CollectionState, player: int) -> bool:
-    return can_beat_moldarach(state, player) and (
-        has_beetle(state, player) or has_bow(state, player)
+    return can_beat_moldarach(state, player) & (
+        has_beetle(state, player) | has_bow(state, player)
     )  # To hit the timeshift stone
 
 
 # Ancient Cistern
 def can_enter_AC_statue(state: CollectionState, player: int) -> bool:
-    return state.can_reach_region("Ancient Cistern", player) and (
+    return state.can_reach_region("Ancient Cistern", player) & (
         state.has("Ancient Cistern Small Key", player, 2)
-        or can_lower_AC_statue(state, player)
+        | can_lower_AC_statue(state, player)
     )
 
 
 def can_lower_AC_statue(state: CollectionState, player: int) -> bool:
-    return can_reach_AC_vines(state, player) and state.has("Whip", player)
+    return can_reach_AC_vines(state, player) & state.has("Whip", player)
 
 
 def can_pass_AC_waterfall(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and state.has("Whip", player)
+        & state.has("Water Dragon's Scale", player)
+        & state.has("Whip", player)
     )
 
 
 def can_reach_AC_boko_key_door(state: CollectionState, player: int) -> bool:
     return (
         can_pass_AC_waterfall(state, player)
-        and state.has("Whip", player)
-        and state.has("Water Dragon's Scale", player)
-        and (has_beetle(state, player) or has_bow(state, player))
+        & state.has("Whip", player)
+        & state.has("Water Dragon's Scale", player)
+        & (has_beetle(state, player) | has_bow(state, player))
     )
 
 
 def can_reach_AC_vines(state: CollectionState, player: int) -> bool:
-    return state.can_reach_region("Ancient Cistern", player) and (
-        (state.has("Clawshots", player) and state.has("Whip", player))
-        or (
+    return state.can_reach_region("Ancient Cistern", player) & (
+        (state.has("Clawshots", player) & state.has("Whip", player))
+        | (
             can_reach_AC_boko_key_door(state, player)
-            and state.has("Ancient Cistern Small Key", player, 2)
+            & state.has("Ancient Cistern Small Key", player, 2)
         )
     )
 
 
 def can_reach_AC_thread(state: CollectionState, player: int) -> bool:
-    return can_lower_AC_statue(state, player) and (
-        state.has("Clawshots", player) or has_hook_beetle(state, player)
+    return can_lower_AC_statue(state, player) & (
+        state.has("Clawshots", player) | has_hook_beetle(state, player)
     )
 
 
 def can_reach_AC_boss_door(state: CollectionState, player: int) -> bool:
     return (  # This means can reach the very TOP of the dungeon after the boss key is put in
         can_enter_AC_statue(state, player)
-        and state.has("Whip", player)  # Whip valves
-        and state.has("Ancient Cistern Boss Key", player)
+        & state.has("Whip", player)  # Whip valves
+        & state.has("Ancient Cistern Boss Key", player)
     )
 
 
 def can_beat_koloktos(state: CollectionState, player: int) -> bool:
     return (
         can_reach_AC_boss_door(state, player)
-        and state.has("Whip", player)
-        and (
+        & state.has("Whip", player)
+        & (
             has_practice_sword(state, player)
-            or has_bow(state, player)
-            or state.has("Bomb Bag", player)
+            | has_bow(state, player)
+            | state.has("Bomb Bag", player)
         )
     )
 
 
 def can_beat_AC(state: CollectionState, player: int) -> bool:
-    return can_beat_koloktos(state, player) and has_goddess_sword(state, player)
+    return can_beat_koloktos(state, player) & has_goddess_sword(state, player)
 
 
 # Sandship
 def can_change_SSH_temporality(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Sandship", player)
-        and has_bow(state, player)
-        and (
+        & has_bow(state, player)
+        & (
             has_practice_sword(state, player)
-            or state.has("Sandship Small Key", player, 2)
+            | state.has("Sandship Small Key", player, 2)
         )
     )
 
 
 def can_reach_SSH_4_door_corridor(state: CollectionState, player: int) -> bool:
-    return state.can_reach_region("Sandship", player) and (
+    return state.can_reach_region("Sandship", player) & (
         can_change_SSH_temporality(state, player)
-        or has_goddess_sword(state, player)
-        or has_bow(state, player)
-        or has_slingshot(state, player)
-        or state.has("Bomb Bag", player)
+        | has_goddess_sword(state, player)
+        | has_bow(state, player)
+        | has_slingshot(state, player)
+        | state.has("Bomb Bag", player)
     )
 
 
 def can_reach_SSH_brig(state: CollectionState, player: int) -> bool:
     return (
         can_change_SSH_temporality(state, player)
-        and has_practice_sword(state, player)
-        and has_bow(state, player)
-        and state.has("Whip", player)
+        & has_practice_sword(state, player)
+        & has_bow(state, player)
+        & state.has("Whip", player)
     )
 
 
@@ -1393,117 +1393,117 @@ def can_reach_SSH_boss_door(state: CollectionState, player: int) -> bool:
 def can_beat_tentalus(state: CollectionState, player: int) -> bool:
     return (
         can_reach_SSH_boss_door(state, player)
-        and state.has("Sandship Boss Key", player)
-        and has_bow(state, player)
+        & state.has("Sandship Boss Key", player)
+        & has_bow(state, player)
     )
 
 
 def can_beat_SSH(state: CollectionState, player: int) -> bool:
-    return can_beat_tentalus(state, player) and has_goddess_sword(state, player)
+    return can_beat_tentalus(state, player) & has_goddess_sword(state, player)
 
 
 # Fire Sanctuary
 def can_reach_FS_first_magmanos_room(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Fire Sanctuary", player)
-        and state.has("Fire Sanctuary Small Key", player)
-        and (distance_activator(state, player) or state.has("Bomb Bag", player))
+        & state.has("Fire Sanctuary Small Key", player)
+        & (distance_activator(state, player) | state.has("Bomb Bag", player))
     )
 
 
 def can_reach_FS_water_pod_room(state: CollectionState, player: int) -> bool:
     return (
         can_reach_FS_first_magmanos_room(state, player)
-        and can_defeat_lezalfos(state, player)
-        and has_hook_beetle(state, player)
-        and state.has("Fire Sanctuary Small Key", player, 2)
+        & can_defeat_lezalfos(state, player)
+        & has_hook_beetle(state, player)
+        & state.has("Fire Sanctuary Small Key", player, 2)
     )
 
 
 def can_reach_FS_second_bridge(state: CollectionState, player: int) -> bool:
     return (
         can_reach_FS_water_pod_room(state, player)
-        and has_practice_sword(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Gust Bellows", player)
+        & has_practice_sword(state, player)
+        & has_mogma_mitts(state, player)
+        & state.has("Gust Bellows", player)
     )
 
 
 def can_reach_FS_plats_room(state: CollectionState, player: int) -> bool:
     return (
         can_reach_FS_water_pod_room(state, player)
-        and has_practice_sword(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Fire Sanctuary Small Key", player, 3)
-        and (
-            distance_activator(state, player) or state.has("Bomb Bag", player)
+        & has_practice_sword(state, player)
+        & has_mogma_mitts(state, player)
+        & state.has("Fire Sanctuary Small Key", player, 3)
+        & (
+            distance_activator(state, player) | state.has("Bomb Bag", player)
         )  # for water pod
     )
 
 
 def can_reach_FS_boss_door(state: CollectionState, player: int) -> bool:
-    return can_reach_FS_plats_room(state, player) and has_mogma_mitts(state, player)
+    return can_reach_FS_plats_room(state, player) & has_mogma_mitts(state, player)
 
 
 def can_reach_top_of_FS_staircase(state: CollectionState, player: int) -> bool:
     return (
         can_reach_FS_boss_door(state, player)
-        and can_defeat_lezalfos(state, player)
-        and state.has("Clawshots", player)
+        & can_defeat_lezalfos(state, player)
+        & state.has("Clawshots", player)
     )
 
 
 def can_beat_ghirahim_2(state: CollectionState, player: int) -> bool:
     return (
         can_reach_FS_boss_door(state, player)
-        and state.has("Fire Sanctuary Boss Key", player)
-        and has_practice_sword(state, player)
+        & state.has("Fire Sanctuary Boss Key", player)
+        & has_practice_sword(state, player)
     )
 
 
 def can_beat_FS(state: CollectionState, player: int) -> bool:
-    return can_beat_ghirahim_2(state, player) and has_goddess_sword(state, player)
+    return can_beat_ghirahim_2(state, player) & has_goddess_sword(state, player)
 
 
 # Sky Keep
 def can_pass_SK_sv_room(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Sky Keep", player)
-        and (has_beetle(state, player) or has_bow(state, player))
-        and state.has("Whip", player)
-        and state.has("Clawshots", player)
-        and (
+        & (has_beetle(state, player) | has_bow(state, player))
+        & state.has("Whip", player)
+        & state.has("Clawshots", player)
+        & (
             state.has("Bomb Bag", player)
-            or has_hook_beetle(state, player)
-            or has_bow(state, player)
+            | has_hook_beetle(state, player)
+            | has_bow(state, player)
         )
-        and state.has("Gust Bellows", player)
+        & state.has("Gust Bellows", player)
     )
 
 
 def can_pass_SK_lmf_room(state: CollectionState, player: int) -> bool:
     return (
         can_pass_SK_sv_room(state, player)
-        and has_bow(state, player)
-        and state.has("Gust Bellows", player)
+        & has_bow(state, player)
+        & state.has("Gust Bellows", player)
     )
 
 
 def can_pass_SK_et_room(state: CollectionState, player: int) -> bool:
     return (
         can_pass_SK_lmf_room(state, player)
-        and has_mogma_mitts(state, player)
-        and has_hook_beetle(state, player)
-        and state.has("Bomb Bag", player)
-        and upgraded_skyward_strike(state, player)
+        & has_mogma_mitts(state, player)
+        & has_hook_beetle(state, player)
+        & state.has("Bomb Bag", player)
+        & upgraded_skyward_strike(state, player)
     )
 
 
 def can_pass_SK_mini_boss_room(state: CollectionState, player: int) -> bool:
     return (
-        (can_pass_SK_et_room(state, player) or can_pass_SK_fs_room(state, player))
-        and has_practice_sword(state, player)
-        and state.has("Clawshots", player)
+        (can_pass_SK_et_room(state, player) | can_pass_SK_fs_room(state, player))
+        & has_practice_sword(state, player)
+        & state.has("Clawshots", player)
     )
 
 
@@ -1514,21 +1514,21 @@ def can_pass_SK_ac_room(state: CollectionState, player: int) -> bool:
 def can_get_triforce_of_courage(state: CollectionState, player: int) -> bool:
     return (
         can_pass_SK_ac_room(state, player)
-        and state.has("Sky Keep Small Key", player)
-        and can_defeat_moblins(state, player)
-        and can_defeat_bokoblins(state, player)
-        and can_defeat_stalfos(state, player)
-        and has_bow(state, player)
-        and can_defeat_cursed_bokoblins(state, player)
-        and can_defeat_stalmaster(state, player)
+        & state.has("Sky Keep Small Key", player)
+        & can_defeat_moblins(state, player)
+        & can_defeat_bokoblins(state, player)
+        & can_defeat_stalfos(state, player)
+        & has_bow(state, player)
+        & can_defeat_cursed_bokoblins(state, player)
+        & can_defeat_stalmaster(state, player)
     )
 
 
 def can_pass_SK_fs_room(state: CollectionState, player: int) -> bool:
     return (
         can_pass_SK_ac_room(state, player)
-        and has_beetle(state, player)
-        and state.has("Clawshots", player)
+        & has_beetle(state, player)
+        & state.has("Clawshots", player)
     )
 
 
@@ -1539,8 +1539,8 @@ def can_get_triforce_of_power(state: CollectionState, player: int) -> bool:
 def can_pass_SK_ssh_room(state: CollectionState, player: int) -> bool:
     return (
         can_pass_SK_fs_room(state, player)
-        and has_bow(state, player)
-        and state.has("Clawshots", player)
+        & has_bow(state, player)
+        & state.has("Clawshots", player)
     )
 
 
@@ -1551,9 +1551,9 @@ def can_get_triforce_of_wisdom(state: CollectionState, player: int) -> bool:
 def can_beat_SK(state: CollectionState, player: int) -> bool:
     return (
         state.can_reach_region("Sky Keep", player)
-        and can_get_triforce_of_courage(state, player)
-        and can_get_triforce_of_power(state, player)
-        and can_get_triforce_of_wisdom(state, player)
+        & can_get_triforce_of_courage(state, player)
+        & can_get_triforce_of_power(state, player)
+        & can_get_triforce_of_wisdom(state, player)
     )
 
 

--- a/worlds/ss/Rules.py
+++ b/worlds/ss/Rules.py
@@ -25,28 +25,38 @@ class SSLogic(LogicMixin):
         return (
             (
                 has_goddess_sword(self, player)
-                and self.multiworld.worlds[player].options.got_sword_requirement
-                == "goddess_sword"
+                & (
+                    self.multiworld.worlds[player].options.got_sword_requirement
+                    == "goddess_sword"
+                )
             )
-            or (
+            | (
                 has_goddess_longsword(self, player)
-                and self.multiworld.worlds[player].options.got_sword_requirement
-                == "goddess_longsword"
+                & (
+                    self.multiworld.worlds[player].options.got_sword_requirement
+                    == "goddess_longsword"
+                )
             )
-            or (
+            | (
                 has_goddess_white_sword(self, player)
-                and self.multiworld.worlds[player].options.got_sword_requirement
-                == "goddess_white_sword"
+                & (
+                    self.multiworld.worlds[player].options.got_sword_requirement
+                    == "goddess_white_sword"
+                )
             )
-            or (
+            | (
                 has_master_sword(self, player)
-                and self.multiworld.worlds[player].options.got_sword_requirement
-                == "master_sword"
+                & (
+                    self.multiworld.worlds[player].options.got_sword_requirement
+                    == "master_sword"
+                )
             )
-            or (
+            | (
                 has_true_master_sword(self, player)
-                and self.multiworld.worlds[player].options.got_sword_requirement
-                == "true_master_sword"
+                & (
+                    self.multiworld.worlds[player].options.got_sword_requirement
+                    == "true_master_sword"
+                )
             )
         )
 
@@ -55,9 +65,12 @@ class SSLogic(LogicMixin):
             player
         ].dungeons.required_dungeon_checks
         return all(self.can_reach_location(loc, player) for loc in req_dungeon_checks)
-    
+
     def _ss_option_unrequired_dungeons(self, player: int) -> bool:
-        return self.multiworld.worlds[player].options.got_dungeon_requirement == "unrequired"
+        return (
+            self.multiworld.worlds[player].options.got_dungeon_requirement
+            == "unrequired"
+        )
 
     def _ss_option_upgraded_skyward_strike(self, player: int) -> bool:
         return self.multiworld.worlds[player].options.upgraded_skyward_strike
@@ -69,7 +82,7 @@ class SSLogic(LogicMixin):
         return self.multiworld.worlds[player].options.open_thunderhead == "open"
 
     def _ss_option_no_triforce(self, player: int) -> bool:
-        return not self.multiworld.worlds[player].options.triforce_required
+        return ~self.multiworld.worlds[player].options.triforce_required
 
     def _ss_option_lake_floria_open(self, player: int) -> bool:
         return self.multiworld.worlds[player].options.open_lake_floria == "open"
@@ -118,7 +131,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Upper Skyloft - Ring Knight Academy Bell",
         lambda state: distance_activator(state, player)
-        or state.has("Gust Bellows", player),
+        | state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Upper Skyloft - Chest near Goddess Statue", lambda state: True
@@ -136,12 +149,12 @@ def set_rules(world: "SSWorld") -> None:
     )
     set_rule_if_progression(
         "Upper Skyloft - Owlan's Crystals",
-        lambda state: can_reach_oolo(state, player) and state.has("Scrapper", player),
+        lambda state: can_reach_oolo(state, player) & state.has("Scrapper", player),
     )
     set_rule_if_progression(
         "Upper Skyloft - Fledge's Crystals",
         lambda state: has_bottle(state, player)
-        and unlocked_endurance_potion(state, player),
+        & unlocked_endurance_potion(state, player),
     )
     set_rule_if_progression(
         "Upper Skyloft - Item from Cawlin",
@@ -160,12 +173,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Central Skyloft - Repair Gondo's Junk",
         lambda state: state.has("Amber Tablet", player)
-        and (
+        & (
             lanayru_mine_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming(state, player)
-            or lanayru_desert_ancient_flower_farming_near_main_node(state, player)
-            or pirate_stronghold_ancient_flower_farming(state, player)
-            or lanayru_gorge_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming(state, player)
+            | lanayru_desert_ancient_flower_farming_near_main_node(state, player)
+            | pirate_stronghold_ancient_flower_farming(state, player)
+            | lanayru_gorge_ancient_flower_farming(state, player)
         ),
     )
     set_rule_if_progression("Central Skyloft - Wryna's Crystals", lambda state: True)
@@ -192,7 +205,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Central Skyloft - Item in Bird Nest",
         lambda state: state.has("Clawshots", player)
-        and state.has("Gust Bellows", player),
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Central Skyloft - Shed Chest",
@@ -209,17 +222,17 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Central Skyloft - Shed Goddess Chest",
         lambda state: goddess_cube_on_sand_slide(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Central Skyloft - Floating Island Goddess Chest",
         lambda state: goddess_cube_in_lake_floria(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Central Skyloft - Waterfall Goddess Chest",
         lambda state: goddess_cube_in_pirate_stronghold(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
 
     set_rule_if_progression(
@@ -233,8 +246,8 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Skyloft Village - Sparrot's Crystals",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Scrapper", player),
+        & state.has("Clawshots", player)
+        & state.has("Scrapper", player),
     )
 
     set_rule_if_progression(
@@ -277,30 +290,30 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Beedle's Shop - 300 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_300_rupees(state, player)
-        and (has_pouch(state, player) or state._ss_option_shopsanity(player)),
+        & can_afford_300_rupees(state, player)
+        & (has_pouch(state, player) | state._ss_option_shopsanity(player)),
     )
     set_rule_if_progression(
         "Beedle's Shop - 600 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_600_rupees(state, player)
-        and (has_pouch(state, player) or state._ss_option_shopsanity(player)),
+        & can_afford_600_rupees(state, player)
+        & (has_pouch(state, player) | state._ss_option_shopsanity(player)),
     )
     set_rule_if_progression(
         "Beedle's Shop - 1200 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_1200_rupees(state, player)
-        and (has_pouch(state, player) or state._ss_option_shopsanity(player)),
+        & can_afford_1200_rupees(state, player)
+        & (has_pouch(state, player) | state._ss_option_shopsanity(player)),
     )
     set_rule_if_progression(
         "Beedle's Shop - 800 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_800_rupees(state, player),
+        & can_afford_800_rupees(state, player),
     )
     set_rule_if_progression(
         "Beedle's Shop - 1600 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_1600_rupees(state, player),
+        & can_afford_1600_rupees(state, player),
     )
     set_rule_if_progression(
         "Beedle's Shop - First 100 Rupee Item",
@@ -313,7 +326,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Beedle's Shop - Third 100 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_medium_rupee_farm(state, player),
+        & can_medium_rupee_farm(state, player),
     )
     set_rule_if_progression(
         "Beedle's Shop - 50 Rupee Item",
@@ -322,20 +335,20 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Beedle's Shop - 1000 Rupee Item",
         lambda state: can_access_beedles_shop(state, player)
-        and can_afford_1000_rupees(state, player),
+        & can_afford_1000_rupees(state, player),
     )
 
     set_rule_if_progression("Sky - Lumpy Pumpkin - Chandelier", lambda state: True)
     set_rule_if_progression(
         "Sky - Lumpy Pumpkin - Harp Minigame",
         lambda state: state.has("Goddess's Harp", player)
-        and has_bottle(state, player),  # Bottle for soup quest
+        & has_bottle(state, player),  # Bottle for soup quest
     )
     set_rule_if_progression(
         "Sky - Kina's Crystals",
         lambda state: state.has("Scrapper", player)
-        and has_bottle(state, player)
-        and state.can_reach_region("Mogma Turf", player),
+        & has_bottle(state, player)
+        & state.can_reach_region("Mogma Turf", player),
     )
     set_rule_if_progression(
         "Sky - Orielle's Crystals", lambda state: can_save_orielle(state, player)
@@ -343,7 +356,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sky - Beedle's Crystals",
         lambda state: can_access_beedles_shop(state, player)
-        and state.has("Horned Colossus Beetle", player),
+        & state.has("Horned Colossus Beetle", player),
     )
     set_rule_if_progression(
         "Sky - Dodoh's Crystals", lambda state: can_retrieve_party_wheel(state, player)
@@ -371,7 +384,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sky - Goddess Chest in Cave on Island next to Bamboo Island",
         lambda state: goddess_cube_in_secret_passageway(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Sky - Beedle's Island Goddess Chest",
@@ -380,12 +393,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sky - Beedle's Island Cage Goddess Chest",
         lambda state: goddess_cube_on_top_on_skyview(state, player)
-        and can_access_beedles_shop(state, player),
+        & can_access_beedles_shop(state, player),
     )
     set_rule_if_progression(
         "Sky - Northeast Island Goddess Chest behind Bombable Rocks",
         lambda state: goddess_cube_at_lanayru_mine_entrance(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Sky - Northeast Island Cage Goddess Chest",
@@ -412,7 +425,7 @@ def set_rules(world: "SSWorld") -> None:
         lambda state: goddess_cube_on_east_great_tree_with_clawshot_target(
             state, player
         )
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Sky - Goddess Chest under Fun Fun Island",
@@ -429,73 +442,73 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sky - Southwest Triple Island Cage Goddess Chest",
         lambda state: goddess_cube_in_skippers_retreat(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
 
     # Thunderhead
     set_rule_if_progression(
         "Thunderhead - Isle of Songs - Strike Crest with Goddess Sword",
         lambda state: can_access_thunderhead(state, player)
-        and has_goddess_sword(state, player),
+        & has_goddess_sword(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Isle of Songs - Strike Crest with Longsword",
         lambda state: can_access_thunderhead(state, player)
-        and has_goddess_longsword(state, player),
+        & has_goddess_longsword(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Isle of Songs - Strike Crest with White Sword",
         lambda state: can_access_thunderhead(state, player)
-        and has_goddess_white_sword(state, player),
+        & has_goddess_white_sword(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Song from Levias",
         lambda state: can_access_thunderhead(state, player)
-        and has_practice_sword(state, player)
-        and state.has("Scrapper", player)
-        and state.has("Spiral Charge", player),
+        & has_practice_sword(state, player)
+        & state.has("Scrapper", player)
+        & state.has("Spiral Charge", player),
     )
     set_rule_if_progression(
         "Thunderhead - Bug Heaven -- 10 Bugs in 3 Minutes",
         lambda state: can_access_thunderhead(state, player)
-        and has_bug_net(state, player),
+        & has_bug_net(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - East Island Chest",
         lambda state: can_access_thunderhead(state, player)
-        and has_digging_mitts(state, player),
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - East Island Goddess Chest",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_on_east_great_tree_with_rope(state, player),
+        & goddess_cube_on_east_great_tree_with_rope(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Goddess Chest on top of Isle of Songs",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_near_fire_sanctuary_entrance(state, player),
+        & goddess_cube_near_fire_sanctuary_entrance(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Goddess Chest outside Isle of Songs",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_in_mogma_turf(state, player),
+        & goddess_cube_in_mogma_turf(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - First Goddess Chest on Mogma Mitts Island",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_inside_volcano_summit(state, player)
-        and has_mogma_mitts(state, player),
+        & goddess_cube_inside_volcano_summit(state, player)
+        & has_mogma_mitts(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Second Goddess Chest on Mogma Mitts Island",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_in_lanayru_gorge(state, player)
-        and has_mogma_mitts(state, player),
+        & goddess_cube_in_lanayru_gorge(state, player)
+        & has_mogma_mitts(state, player),
     )
     set_rule_if_progression(
         "Thunderhead - Bug Heaven Goddess Chest",
         lambda state: can_access_thunderhead(state, player)
-        and goddess_cube_in_summit_waterfall(state, player),
+        & goddess_cube_in_summit_waterfall(state, player),
     )
 
     # Sealed Grounds
@@ -506,14 +519,14 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sealed Grounds - Song from Impa",
         lambda state: can_reach_sealed_temple(state, player)
-        and state.has("Goddess's Harp", player),
+        & state.has("Goddess's Harp", player),
     )
     set_rule_if_progression(
         "Sealed Grounds - Gorko's Goddess Wall Reward",
         lambda state: can_reach_sealed_temple(state, player)
-        and state.has("Goddess's Harp", player)
-        and state.has("Ballad of the Goddess", player)
-        and has_goddess_sword(state, player),
+        & state.has("Goddess's Harp", player)
+        & state.has("Ballad of the Goddess", player)
+        & has_goddess_sword(state, player),
     )
     set_rule_if_progression(
         "Sealed Grounds - Zelda's Blessing", lambda state: can_reach_past(state, player)
@@ -523,7 +536,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Faron Woods - Item behind Lower Bombable Rock",
         lambda state: can_reach_most_of_faron_woods(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Faron Woods - Item on Tree",
@@ -532,8 +545,8 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Faron Woods - Kikwi Elder's Reward",
         lambda state: can_reach_most_of_faron_woods(state, player)
-        and can_defeat_bokoblins(state, player)
-        and (has_practice_sword(state, player) or has_beetle(state, player)),
+        & can_defeat_bokoblins(state, player)
+        & (has_practice_sword(state, player) | has_beetle(state, player)),
     )
     set_rule_if_progression(
         "Faron Woods - Rupee on Hollow Tree Root",
@@ -542,12 +555,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Faron Woods - Rupee on Hollow Tree Branch",
         lambda state: can_reach_most_of_faron_woods(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Faron Woods - Rupee on Platform near Floria Door",
         lambda state: can_reach_most_of_faron_woods(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Faron Woods - Deep Woods Chest",
@@ -556,27 +569,27 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Faron Woods - Chest behind Upper Bombable Rock",
         lambda state: can_reach_most_of_faron_woods(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Faron Woods - Chest inside Great Tree",
         lambda state: (
-            can_reach_great_tree(state, player) and state.has("Gust Bellows", player)
+            can_reach_great_tree(state, player) & state.has("Gust Bellows", player)
         )
-        or (
+        | (
             can_reach_top_of_great_tree(state, player)
-            and can_defeat_moblins(state, player)
+            & can_defeat_moblins(state, player)
         ),
     )
     set_rule_if_progression(
         "Faron Woods - Rupee on Great Tree North Branch",
         lambda state: can_reach_top_of_great_tree(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Faron Woods - Rupee on Great Tree West Branch",
         lambda state: can_reach_top_of_great_tree(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
 
     # Lake Floria
@@ -603,7 +616,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lake Floria - Dragon Lair South Chest",
         lambda state: can_reach_floria_waterfall(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Lake Floria - Dragon Lair East Chest",
@@ -612,99 +625,99 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lake Floria - Rupee on High Ledge outside Ancient Cistern Entrance",
         lambda state: can_reach_floria_waterfall(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
 
     # Flooded Faron Woods
     set_rule_if_progression(
         "Flooded Faron Woods - Yellow Tadtone under Lilypad",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 8 Light Blue Tadtones near Viewing Platform",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 4 Purple Tadtones under Viewing Platform",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - Red Moving Tadtone near Viewing Platform",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - Light Blue Tadtone under Great Tree Root",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 8 Yellow Tadtones near Kikwi Elder",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 4 Light Blue Moving Tadtones under Kikwi Elder",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 4 Red Moving Tadtones North West of Great Tree",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - Green Tadtone behind Upper Bombable Rock",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 2 Dark Blue Tadtones in Grass West of Great Tree",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 8 Green Tadtones in West Tunnel",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 2 Red Tadtones in Grass near Lower Bombable Rock",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 16 Dark Blue Tadtones in the South West",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 4 Purple Moving Tadtones near Floria Gate",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - Dark Blue Moving Tadtone inside Small Hollow Tree",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 4 Yellow Tadtones under Small Hollow Tree",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - 8 Purple Tadtones in Clearing after Small Hollow Tree",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Flooded Faron Woods - Water Dragon's Reward",
         lambda state: can_access_flooded_faron_woods(state, player)
-        and state.has("Group of Tadtones", player, 17),
+        & state.has("Group of Tadtones", player, 17),
     )
 
     # Eldin Volcano
@@ -731,12 +744,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Eldin Volcano - Southeast Rupee above Mogma Turf Entrance",
         lambda state: can_access_eldin_volcano(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - North Rupee above Mogma Turf Entrance",
         lambda state: can_access_eldin_volcano(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - Chest behind Bombable Wall near Cliff",
@@ -761,31 +774,29 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Eldin Volcano - Digging Spot in front of Earth Temple",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and has_digging_mitts(state, player),
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - Digging Spot below Tower",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and has_digging_mitts(state, player),
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - Digging Spot behind Boulder on Sandy Slope",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and has_digging_mitts(state, player),
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - Digging Spot after Vents",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and has_digging_mitts(state, player)
-        and can_survive_eldin_hot_cave(state, player),
+        & has_digging_mitts(state, player)
+        & can_survive_eldin_hot_cave(state, player),
     )
     set_rule_if_progression(
         "Eldin Volcano - Digging Spot after Draining Lava",
         lambda state: can_reach_second_part_of_eldin_volcano(state, player)
-        and has_digging_mitts(state, player)
-        and (
-            can_survive_eldin_hot_cave(state, player) or state.has("Bomb Bag", player)
-        ),
+        & has_digging_mitts(state, player)
+        & (can_survive_eldin_hot_cave(state, player) | state.has("Bomb Bag", player)),
     )
 
     # Mogma Turf
@@ -800,7 +811,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Mogma Turf - Defeat Bokoblins",
         lambda state: can_access_mogma_turf(state, player)
-        and can_defeat_bokoblins(state, player),
+        & can_defeat_bokoblins(state, player),
     )
     set_rule_if_progression(
         "Mogma Turf - Sand Slide Chest",
@@ -815,12 +826,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Volcano Summit - Chest behind Bombable Wall in Waterfall Area",
         lambda state: can_access_volcano_summit(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Volcano Summit - Item behind Digging",
         lambda state: can_pass_volcano_summit_first_frog(state, player)
-        and has_mogma_mitts(state, player),
+        & has_mogma_mitts(state, player),
     )
 
     # Boko Base
@@ -831,99 +842,99 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Bokoblin Base - Chest near Bone Bridge",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player),
+        & has_mogma_mitts(state, player),
     )
     set_rule_if_progression(
         "Bokoblin Base - Chest on Cliff",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Gust Bellows", player),
+        & has_mogma_mitts(state, player)
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Bokoblin Base - Chest near Drawbridge",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and (
+        & has_mogma_mitts(state, player)
+        & (
             state.has("Clawshots", player)
-            or can_bypass_boko_base_watchtower(state, player)
+            | can_bypass_boko_base_watchtower(state, player)
         ),
     )
     set_rule_if_progression(
         "Bokoblin Base - Chest East of Earth Temple Entrance",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and (
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & (
             state.has("Bomb Bag", player)
-            or (
+            | (
                 can_bypass_boko_base_watchtower(state, player)
-                and state.has("Whip", player)
+                & state.has("Whip", player)
             )
         ),
     )
     set_rule_if_progression(
         "Bokoblin Base - Chest West of Earth Temple Entrance",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and (
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & (
             state.has("Bomb Bag", player)
-            or (
+            | (
                 can_bypass_boko_base_watchtower(state, player)
-                and state.has("Whip", player)
+                & state.has("Whip", player)
             )
         ),
     )
     set_rule_if_progression(
         "Bokoblin Base - First Chest in Volcano Summit",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Bomb Bag", player)
-        and state.has("Fireshield Earrings", player),
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & state.has("Bomb Bag", player)
+        & state.has("Fireshield Earrings", player),
     )
     set_rule_if_progression(
         "Bokoblin Base - Raised Chest in Volcano Summit",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Bomb Bag", player)
-        and state.has("Fireshield Earrings", player),
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & state.has("Bomb Bag", player)
+        & state.has("Fireshield Earrings", player),
     )
     set_rule_if_progression(
         "Bokoblin Base - Chest in Volcano Summit Alcove",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Bomb Bag", player)
-        and state.has("Fireshield Earrings", player)
-        and has_practice_sword(state, player),
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & state.has("Bomb Bag", player)
+        & state.has("Fireshield Earrings", player)
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Bokoblin Base - Fire Dragon's Reward",
         lambda state: can_access_bokoblin_base(state, player)
-        and has_mogma_mitts(state, player)
-        and state.has("Clawshots", player)
-        and state.has("Bomb Bag", player)
-        and state.has("Fireshield Earrings", player)
-        and (has_beetle(state, player) or has_bow(state, player)),
+        & has_mogma_mitts(state, player)
+        & state.has("Clawshots", player)
+        & state.has("Bomb Bag", player)
+        & state.has("Fireshield Earrings", player)
+        & (has_beetle(state, player) | has_bow(state, player)),
     )
 
     # Lanayru Mine
     set_rule_if_progression(
         "Lanayru Mine - Chest behind First Landing",
         lambda state: can_access_lanayru_mine(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Lanayru Mine - Chest near First Timeshift Stone",
         lambda state: can_access_lanayru_mine(state, player)
-        and can_hit_timeshift_stone(state, player),
+        & can_hit_timeshift_stone(state, player),
     )
     set_rule_if_progression(
         "Lanayru Mine - Chest behind Statue",
         lambda state: can_reach_second_part_of_lanayru_mine(state, player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player)),
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player)),
     )
     set_rule_if_progression(
         "Lanayru Mine - Chest at the End of Mine",
@@ -934,7 +945,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Desert - Chest near Party Wheel",
         lambda state: can_access_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Chest near Caged Robot",
@@ -943,22 +954,22 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Desert - Rescue Caged Robot",
         lambda state: can_access_lanayru_desert(state, player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player)),
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player)),
     )
     set_rule_if_progression(
         "Lanayru Desert - Chest on Platform near Fire Node",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Chest on Platform near Lightning Node",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Chest near Sand Oasis",
         lambda state: can_access_lanayru_desert(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Chest on top of Lanayru Mining Facility",
@@ -967,56 +978,56 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Desert - Secret Passageway Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and (state.has("Bomb Bag", player) or has_tough_beetle(state, player)),
+        & (state.has("Bomb Bag", player) | has_tough_beetle(state, player)),
     )
 
     # Fire node
     set_rule_if_progression(
         "Lanayru Desert - Fire Node - Shortcut Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and can_defeat_ampilus(state, player),
+        & can_defeat_ampilus(state, player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Fire Node - First Small Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Fire Node - Second Small Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Fire Node - Left Ending Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and can_defeat_ampilus(state, player)
-        and state.has("Bomb Bag", player)
-        and has_hook_beetle(state, player),
+        & can_defeat_ampilus(state, player)
+        & state.has("Bomb Bag", player)
+        & has_hook_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Fire Node - Right Ending Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and can_defeat_ampilus(state, player)
-        and state.has("Bomb Bag", player)
-        and has_hook_beetle(state, player),
+        & can_defeat_ampilus(state, player)
+        & state.has("Bomb Bag", player)
+        & has_hook_beetle(state, player),
     )
 
     # Lightning node
     set_rule_if_progression(
         "Lanayru Desert - Lightning Node - First Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Lightning Node - Second Chest",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Lanayru Desert - Lightning Node - Raised Chest near Generator",
         lambda state: can_reach_second_part_of_lanayru_desert(state, player)
-        and state.has("Bomb Bag", player)
-        and (has_beetle(state, player) or has_bow(state, player)),
+        & state.has("Bomb Bag", player)
+        & (has_beetle(state, player) | has_bow(state, player)),
     )
 
     # Lanayru Caves
@@ -1026,107 +1037,107 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Caves - Golo's Gift",  # Clawshots needed to for Golo to spawn
         lambda state: can_access_lanayru_caves(state, player)
-        and state.has("Clawshots", player),
+        & state.has("Clawshots", player),
     )
 
     # Lanayru Gorge
     set_rule_if_progression(
         "Lanayru Gorge - Thunder Dragon's Reward",
         lambda state: can_access_lanayru_gorge(state, player)
-        and can_hit_timeshift_stone(state, player)
-        and state.has("Life Tree Fruit", player),
+        & can_hit_timeshift_stone(state, player)
+        & state.has("Life Tree Fruit", player),
     )
     set_rule_if_progression(
         "Lanayru Gorge - Item on Pillar",
         lambda state: can_access_lanayru_gorge(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Gorge - Digging Spot",
         lambda state: can_access_lanayru_gorge(state, player)
-        and can_hit_timeshift_stone(state, player)
-        and state.has("Gust Bellows", player)
-        and has_digging_mitts(state, player),
+        & can_hit_timeshift_stone(state, player)
+        & state.has("Gust Bellows", player)
+        & has_digging_mitts(state, player),
     )
 
     # Lanayru Sand Sea
     set_rule_if_progression(
         "Lanayru Sand Sea - Ancient Harbour - Rupee on First Pillar",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Ancient Harbour - Left Rupee on Entrance Crown",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_quick_beetle(state, player),
+        & has_quick_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Ancient Harbour - Right Rupee on Entrance Crown",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_quick_beetle(state, player),
+        & has_quick_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Skipper's Retreat - Chest after Moblin",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player)),
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player)),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Skipper's Retreat - Chest on top of Cacti Pillar",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and state.has("Whip", player)
-        and state.has("Clawshots", player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player))
-        and (
+        & state.has("Whip", player)
+        & state.has("Clawshots", player)
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player))
+        & (
             has_slingshot(state, player)
-            or has_beetle(state, player)
-            or has_bow(state, player)
+            | has_beetle(state, player)
+            | has_bow(state, player)
         ),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Skipper's Retreat - Chest in Shack",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and state.has("Whip", player)
-        and state.has("Clawshots", player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player))
-        and (
+        & state.has("Whip", player)
+        & state.has("Clawshots", player)
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player))
+        & (
             has_slingshot(state, player)
-            or has_beetle(state, player)
-            or has_bow(state, player)
+            | has_beetle(state, player)
+            | has_bow(state, player)
         )
-        and state.has("Gust Bellows", player),
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Skipper's Retreat - Skydive Chest",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and state.has("Whip", player)
-        and state.has("Clawshots", player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player))
-        and (
+        & state.has("Whip", player)
+        & state.has("Clawshots", player)
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player))
+        & (
             has_slingshot(state, player)
-            or has_beetle(state, player)
-            or has_bow(state, player)
+            | has_beetle(state, player)
+            | has_bow(state, player)
         ),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Rickety Coaster -- Heart Stopping Track in 1'05",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and state.has("Gust Bellows", player)
-        and can_defeat_moldarachs(state, player),
+        & state.has("Gust Bellows", player)
+        & can_defeat_moldarachs(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Pirate Stronghold - Rupee on East Sea Pillar",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_quick_beetle(state, player),
+        & has_quick_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Pirate Stronghold - Rupee on West Sea Pillar",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_quick_beetle(state, player),
+        & has_quick_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Pirate Stronghold - Rupee on Bird Statue Pillar or Nose",
         lambda state: can_access_lanayru_sand_sea(state, player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Lanayru Sand Sea - Pirate Stronghold - First Chest",
@@ -1145,63 +1156,60 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Skyview - Chest on Tree Branch",
         lambda state: can_reach_SV_second_room(state, player)
-        and (
+        & (
             distance_activator(state, player)
-            or has_goddess_sword(state, player)
-            or state.has("Whip", player)
+            | has_goddess_sword(state, player)
+            | state.has("Whip", player)
         ),
     )
     set_rule_if_progression(
         "Skyview - Digging Spot in Crawlspace",
         lambda state: can_reach_SV_second_room(state, player)
-        and distance_activator(state, player)
-        and state.has("Water Dragon's Scale", player)
-        and has_digging_mitts(state, player),
+        & distance_activator(state, player)
+        & state.has("Water Dragon's Scale", player)
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Skyview - Chest behind Two Eyes",
         lambda state: can_reach_SV_second_room(state, player)
-        and (state.has("Clawshots", player) or distance_activator(state, player))
-        and has_practice_sword(state, player),
+        & (state.has("Clawshots", player) | distance_activator(state, player))
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Skyview - Chest after Stalfos Fight",
         lambda state: can_reach_SV_main_room(state, player)
-        and distance_activator(
+        & distance_activator(
             state, player
-        )  # Sword for fight, or scale to skip fight in SV 2
-        and (
+        )  # Sword for fight, | scale to skip fight in SV 2
+        & (
             has_practice_sword(state, player)
-            or state.has("Water Dragon's Scale", player)
+            | state.has("Water Dragon's Scale", player)
         ),
     )
     set_rule_if_progression(
         "Skyview - Item behind Bars",
         lambda state: can_reach_SV_main_room(state, player)
-        and (
-            has_beetle(state, player) or state.has("Whip", player)
-        ),  # Beetle for crystal or whip item
+        & (
+            has_beetle(state, player) | state.has("Whip", player)
+        ),  # Beetle for crystal | whip item
     )
     set_rule_if_progression(
         "Skyview - Rupee in Southeast Tunnel",
-        lambda state: can_reach_SV_main_room(state, player)
-        and has_beetle(state, player),
+        lambda state: can_reach_SV_main_room(state, player) & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Skyview - Rupee in Southwest Tunnel",
-        lambda state: can_reach_SV_main_room(state, player)
-        and has_beetle(state, player),
+        lambda state: can_reach_SV_main_room(state, player) & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Skyview - Rupee in East Tunnel",
-        lambda state: can_reach_SV_main_room(state, player)
-        and has_beetle(state, player),
+        lambda state: can_reach_SV_main_room(state, player) & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Skyview - Chest behind Three Eyes",
         lambda state: can_reach_SV_main_room(state, player)
-        and has_beetle(state, player)
-        and has_practice_sword(state, player),
+        & has_beetle(state, player)
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Skyview - Chest near Boss Door",
@@ -1210,8 +1218,8 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Skyview - Boss Key Chest",
         lambda state: can_reach_SV_boss_door(state, player)
-        and (
-            upgraded_skyward_strike(state, player) or distance_activator(state, player)
+        & (
+            upgraded_skyward_strike(state, player) | distance_activator(state, player)
         ),  # to hit vines
     )
     set_rule_if_progression(
@@ -1219,7 +1227,7 @@ def set_rules(world: "SSWorld") -> None:
     )
     set_rule_if_progression(
         "Skyview - Rupee on Spring Pillar",
-        lambda state: can_beat_ghirahim_1(state, player) and has_beetle(state, player),
+        lambda state: can_beat_ghirahim_1(state, player) & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Skyview - Strike Crest", lambda state: can_beat_SV(state, player)
@@ -1229,12 +1237,12 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Earth Temple - Vent Chest",
         lambda state: state.can_reach_region("Earth Temple", player)
-        and has_digging_mitts(state, player),
+        & has_digging_mitts(state, player),
     )
     set_rule_if_progression(
         "Earth Temple - Rupee above Drawbridge",
         lambda state: state.can_reach_region("Earth Temple", player)
-        and has_beetle(state, player),
+        & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Earth Temple - Chest behind Bombable Rock",
@@ -1247,17 +1255,17 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Earth Temple - Chest in West Room",
         lambda state: can_reach_ET_main_room(state, player)
-        and (state.has("Bomb Bag", player) or has_hook_beetle(state, player)),
+        & (state.has("Bomb Bag", player) | has_hook_beetle(state, player)),
     )
     set_rule_if_progression(
         "Earth Temple - Chest after Double Lizalfos Fight",
         lambda state: can_reach_ET_main_room(state, player)
-        and can_defeat_lezalfos(state, player),
+        & can_defeat_lezalfos(state, player),
     )
     set_rule_if_progression(
         "Earth Temple - Ledd's Gift",
         lambda state: can_reach_ET_main_room(state, player)
-        and can_defeat_lezalfos(state, player),
+        & can_defeat_lezalfos(state, player),
     )
     set_rule_if_progression(
         "Earth Temple - Rupee in Lava Tunnel",
@@ -1290,7 +1298,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Mining Facility - Chest in First West Room",
         lambda state: can_reach_LMF_second_room(state, player)
-        and state.has("Gust Bellows", player),
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Lanayru Mining Facility - Chest after Armos Fight",
@@ -1303,34 +1311,34 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Lanayru Mining Facility - Raised Chest in Hop across Boxes Room",
         lambda state: can_reach_LMF_key_locked_room_in_past(state, player)
-        and (
+        & (
             distance_activator(state, player)
-            or has_practice_sword(state, player)
-            or state.has("Gust Bellows", player)
-            or state.has("Whip", player)
-            or state.has("Bomb Bag", player)
+            | has_practice_sword(state, player)
+            | state.has("Gust Bellows", player)
+            | state.has("Whip", player)
+            | state.has("Bomb Bag", player)
         ),
     )
     set_rule_if_progression(
         "Lanayru Mining Facility - Lower Chest in Hop across Boxes Room",
         lambda state: can_reach_LMF_key_locked_room_in_past(state, player)
-        and (
+        & (
             distance_activator(state, player)
-            or has_practice_sword(state, player)
-            or state.has("Gust Bellows", player)
-            or state.has("Whip", player)
-            or state.has("Bomb Bag", player)
+            | has_practice_sword(state, player)
+            | state.has("Gust Bellows", player)
+            | state.has("Whip", player)
+            | state.has("Bomb Bag", player)
         ),
     )
     set_rule_if_progression(
         "Lanayru Mining Facility - Chest behind First Crawlspace",
         lambda state: can_reach_LMF_hub_room_west(state, player)
-        and state.has("Gust Bellows", player),
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Lanayru Mining Facility - Chest in Spike Maze",
         lambda state: can_reach_LMF_hub_room_west(state, player)
-        and state.has("Gust Bellows", player),
+        & state.has("Gust Bellows", player),
     )
     set_rule_if_progression(
         "Lanayru Mining Facility - Boss Key Chest",
@@ -1353,53 +1361,53 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Ancient Cistern - Rupee in West Hand",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Rupee in East Hand",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player),
+        & state.has("Water Dragon's Scale", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - First Rupee in East Part in Short Tunnel",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Second Rupee in East Part in Short Tunnel",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Third Rupee in East Part in Short Tunnel",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Rupee in East Part in Cubby",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Rupee in East Part in Main Tunnel",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Chest in East Part",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Water Dragon's Scale", player)
-        and can_unlock_combination_lock(state, player),
+        & state.has("Water Dragon's Scale", player)
+        & can_unlock_combination_lock(state, player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Chest after Whip Hooks",
         lambda state: state.can_reach_region("Ancient Cistern", player)
-        and state.has("Whip", player),
+        & state.has("Whip", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Chest near Vines",
@@ -1412,26 +1420,24 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Ancient Cistern - Bokoblin",
         lambda state: can_reach_AC_boko_key_door(state, player)
-        and state.has("Whip", player),
+        & state.has("Whip", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Rupee under Lilypad",
         lambda state: can_reach_AC_boko_key_door(state, player)
-        and state.has("Ancient Cistern Small Key", player, 2)
-        and state.has("Water Dragon's Scale", player)
-        and state.has("Whip", player),
+        & state.has("Ancient Cistern Small Key", player, 2)
+        & state.has("Water Dragon's Scale", player)
+        & state.has("Whip", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Chest in Key Locked Room",
         lambda state: can_enter_AC_statue(state, player)
-        and state.has("Ancient Cistern Small Key", player, 2)
-        and (
-            can_defeat_stalmaster(state, player) or can_lower_AC_statue(state, player)
-        ),
+        & state.has("Ancient Cistern Small Key", player, 2)
+        & (can_defeat_stalmaster(state, player) | can_lower_AC_statue(state, player)),
     )
     set_rule_if_progression(
         "Ancient Cistern - Boss Key Chest",
-        lambda state: can_reach_AC_thread(state, player) and state.has("Whip", player),
+        lambda state: can_reach_AC_thread(state, player) & state.has("Whip", player),
     )
     set_rule_if_progression(
         "Ancient Cistern - Heart Container",
@@ -1445,23 +1451,23 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sandship - Chest at the Stern",
         lambda state: can_change_SSH_temporality(state, player)
-        and has_bow(state, player)
-        and state.has("Clawshots", player),
+        & has_bow(state, player)
+        & state.has("Clawshots", player),
     )
     set_rule_if_progression(
         "Sandship - Chest before 4-Door Corridor",
         lambda state: can_change_SSH_temporality(state, player)
-        and has_bow(state, player),
+        & has_bow(state, player),
     )
     set_rule_if_progression(
         "Sandship - Chest behind Combination Lock",
         lambda state: can_unlock_combination_lock(state, player)
-        and (
+        & (
             (
                 can_reach_SSH_4_door_corridor(state, player)
-                and state.has("Gust Bellows", player)
+                & state.has("Gust Bellows", player)
             )
-            or can_change_SSH_temporality(state, player)
+            | can_change_SSH_temporality(state, player)
         ),
     )
     set_rule_if_progression(
@@ -1491,14 +1497,14 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Sandship - Chest after Scervo Fight",
         lambda state: state.can_reach_region("Sandship", player)
-        and has_practice_sword(state, player)
-        and state.has("Sandship Small Key", player, 2),
+        & has_practice_sword(state, player)
+        & state.has("Sandship Small Key", player, 2),
     )
     set_rule_if_progression(
         "Sandship - Boss Key Chest",
         lambda state: can_change_SSH_temporality(state, player)
-        and has_bow(state, player)
-        and state.has("Sandship Small Key", player, 2),
+        & has_bow(state, player)
+        & state.has("Sandship Small Key", player, 2),
     )
     set_rule_if_progression(
         "Sandship - Heart Container", lambda state: can_beat_tentalus(state, player)
@@ -1511,8 +1517,8 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Fire Sanctuary - Chest in First Room",
         lambda state: state.can_reach_region("Fire Sanctuary", player)
-        and distance_activator(state, player)
-        and can_defeat_bokoblins(state, player),
+        & distance_activator(state, player)
+        & can_defeat_bokoblins(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Chest in Second Room",
@@ -1521,15 +1527,15 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Fire Sanctuary - Chest on Balcony",
         lambda state: can_reach_FS_first_magmanos_room(state, player)
-        and has_mogma_mitts(state, player)
-        and has_practice_sword(state, player),
+        & has_mogma_mitts(state, player)
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Chest near First Trapped Mogma",
         lambda state: can_reach_FS_first_magmanos_room(state, player)
-        and can_defeat_lezalfos(state, player)
-        and has_hook_beetle(state, player)
-        and (state.has("Clawshots", player) or state.has("Gust Bellows", player)),
+        & can_defeat_lezalfos(state, player)
+        & has_hook_beetle(state, player)
+        & (state.has("Clawshots", player) | state.has("Gust Bellows", player)),
     )
     set_rule_if_progression(
         "Fire Sanctuary - First Chest in Water Fruit Room",
@@ -1542,27 +1548,27 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Fire Sanctuary - Rescue First Trapped Mogma",
         lambda state: can_reach_FS_water_pod_room(state, player)
-        and has_practice_sword(state, player),
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Rescue Second Trapped Mogma",
         lambda state: can_reach_FS_second_bridge(state, player)
-        and state.has("Clawshots", player)
-        and has_mogma_mitts(state, player)
-        and has_practice_sword(state, player),
+        & state.has("Clawshots", player)
+        & has_mogma_mitts(state, player)
+        & has_practice_sword(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Chest after Bombable Wall",
         lambda state: can_reach_FS_second_bridge(state, player)
-        and state.has("Clawshots", player)
-        and has_mogma_mitts(state, player)
-        and has_practice_sword(state, player)
-        and state.has("Bomb Bag", player),
+        & state.has("Clawshots", player)
+        & has_mogma_mitts(state, player)
+        & has_practice_sword(state, player)
+        & state.has("Bomb Bag", player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Plats' Chest",
         lambda state: can_reach_FS_plats_room(state, player)
-        and has_mogma_mitts(state, player),
+        & has_mogma_mitts(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Chest in Staircase Room",
@@ -1571,7 +1577,7 @@ def set_rules(world: "SSWorld") -> None:
     set_rule_if_progression(
         "Fire Sanctuary - Boss Key Chest",
         lambda state: can_reach_top_of_FS_staircase(state, player)
-        and has_mogma_mitts(state, player),
+        & has_mogma_mitts(state, player),
     )
     set_rule_if_progression(
         "Fire Sanctuary - Heart Container",
@@ -1592,7 +1598,7 @@ def set_rules(world: "SSWorld") -> None:
     )
     set_rule_if_progression(
         "Sky Keep - Rupee in Fire Sanctuary Room in Alcove",
-        lambda state: can_pass_SK_fs_room(state, player) and has_beetle(state, player),
+        lambda state: can_pass_SK_fs_room(state, player) & has_beetle(state, player),
     )
     set_rule_if_progression(
         "Sky Keep - Sacred Power of Din",

--- a/worlds/ss/test/TestExportLogic.py
+++ b/worlds/ss/test/TestExportLogic.py
@@ -1,0 +1,157 @@
+# This is terrible code that should probably never make it into the AP project
+
+from test.bases import WorldTestBase
+
+
+class BaseRequirement:
+    def __str__(self):
+        raise NotImplementedError()
+
+    def __and__(self, other):
+        if isinstance(other, BaseRequirement):
+            return AndRequirement([self, other])
+        elif other is True:
+            return self
+        elif other is False:
+            return False
+        else:
+            raise ValueError()
+
+    def __rand__(self, other):
+        return self & other
+
+    def __or__(self, other):
+        if isinstance(other, BaseRequirement):
+            return OrRequirement([self, other])
+        elif other is True:
+            return True
+        elif other is False:
+            return self
+        else:
+            raise ValueError()
+
+    def __ror__(self, other):
+        return self & other
+
+    def __invert__(self):
+        return NotRequirement(self)
+
+
+class NotRequirement(BaseRequirement):
+    def __init__(self, term):
+        self.term = term
+
+    def __str__(self):
+        return f"not({self.term})"
+
+
+class AndRequirement(BaseRequirement):
+    def __init__(self, terms):
+        self.terms = terms
+
+    def __str__(self):
+        return f"({' and '.join(str(t) for t in self.terms)})"
+
+
+class OrRequirement(BaseRequirement):
+    def __init__(self, terms):
+        self.terms = terms
+
+    def __str__(self):
+        return f"({' or '.join(str(t) for t in self.terms)})"
+
+
+class ItemCountRequirement(BaseRequirement):
+    def __init__(self, item, count):
+        self.item = item
+        self.count = count
+
+    def __str__(self):
+        return f"count({self.item}, {self.count})"
+
+
+class CanReachRegionRequirement(BaseRequirement):
+    def __init__(self, region):
+        self.region = region
+
+    def __str__(self):
+        return f"can_reach({self.region})"
+
+
+class BaseOption(BaseRequirement):
+    def __init__(self, option):
+        self.option = option
+
+    def __str__(self):
+        return f"option({self.option})"
+
+    def __eq__(self, other):
+        return EqOption(self.option, other)
+
+    def __ne__(self, other):
+        return NeOption(self.option, other)
+
+    def __lt__(self, other):
+        return LtOption(self.option, other)
+
+
+class EqOption(BaseRequirement):
+    def __init__(self, option, value):
+        self.option = option
+        self.value = value
+
+    def __str__(self):
+        return f"option_eq({self.option}, {self.value})"
+
+
+class NeOption(BaseRequirement):
+    def __init__(self, option, value):
+        self.option = option
+        self.value = value
+
+    def __str__(self):
+        return f"option_ne({self.option}, {self.value})"
+
+
+class LtOption(BaseRequirement):
+    def __init__(self, option, value):
+        self.option = option
+        self.value = value
+
+    def __str__(self):
+        return f"option_lt({self.option}, {self.value})"
+
+
+def mock_has(self, item, _player, count=1):
+    return ItemCountRequirement(item, count)
+
+
+def mock_can_reach_region(self, spot, _player):
+    return CanReachRegionRequirement(spot)
+
+
+class MockOptions:
+    def __getattr__(self, name):
+        return BaseOption(name)
+
+
+class SSTestBase(WorldTestBase):
+    game = "Skyward Sword"
+    player: int = 1
+
+
+class TestHackyExportLogic(SSTestBase):
+    options = {
+        "required_dungeon_count": 6,
+        "treasuresanity_in_silent_realms": True,
+        "trial_treasure_amount": 10,
+        "empty_unrequired_dungeons": False,
+    }
+
+    def test_export_logic(self):
+        state = self.multiworld.state
+        state.__class__.has = mock_has
+        state.__class__.can_reach_region = mock_can_reach_region
+        for location in self.multiworld.get_locations(self.player):
+            self.multiworld.worlds[self.player].options = MockOptions()
+            print(location.name, "->", str(location.access_rule(state)))


### PR DESCRIPTION
!!! DO NOT MERGE !!!

I tried to see if it's practical to generate location access rules automatically so that a tracker can run on the actual logic. It works but it's not really practical

Example output:
```
Faron Woods - Rupee on Great Tree North Branch -> ((((count(Emerald Tablet, 1) and ((count(Progressive Sword, 1) or count(Bomb Bag, 1)) or count(Clawshots, 1))) and count(Clawshots, 1)) or (((count(Emerald Tablet, 1) and ((count(Progressive Sword, 1) or count(Bomb Bag, 1)) or count(Clawshots, 1))) and count(Water Dragon's Scale, 1)) and count(Gust Bellows, 1))) and count(Progressive Beetle, 1))
```

So making the actual Python rules more data-driven is probably a better approach