### PR TITLE
fix: seed too long on web and broken option counters with yaml.safe_dump

### DIFF
--- a/worlds/ss/Utils.py
+++ b/worlds/ss/Utils.py
@@ -1,0 +1,23 @@
+import collections
+import yaml
+
+class CounterDumper(yaml.SafeDumper):
+    """A SafeDumper that knows how to serialize collections.Counter."""
+    pass
+
+# whenever we hit a Counter, just treat it as a dict
+CounterDumper.add_representer(
+    collections.Counter,
+    lambda dumper, data: dumper.represent_dict(dict(data))
+)
+CounterDumper.add_multi_representer(
+    collections.Counter,
+    lambda dumper, data: dumper.represent_dict(dict(data))
+)
+
+def restricted_safe_dump(data, **kwargs):
+    """
+    Like yaml.safe_dump, but will also turn any Counter into a plain mapping.
+    Passes all other kwargs through to yaml.dump().
+    """
+    return yaml.dump(data, Dumper=CounterDumper, **kwargs)

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -30,6 +30,7 @@ from .Options import SSOptions
 from .Rules import set_rules
 from .Names import HASH_NAMES
 from .Entrances import AP_ENTRANCE_TABLE
+from .Utils import restricted_safe_dump
 
 from .rando.DungeonRando import DungeonRando
 from .rando.EntranceRando import EntranceRando
@@ -103,8 +104,8 @@ class SSContainer(APContainer, metaclass=AutoPatchRegister):
         """
         super().write_contents(opened_zipfile)
 
-        # Record the data for the game under the key `plando`.
-        opened_zipfile.writestr("plando", b64encode(bytes(yaml.safe_dump(self.data, sort_keys=False), "utf-8")))
+        # Record the data for the game under the key `plando` using the adjusted safe_dump method that supports counters
+        opened_zipfile.writestr("plando", b64encode(bytes(restricted_safe_dump(self.data, sort_keys=False), "utf-8")))
 
 class SSWorld(World):
     """
@@ -439,12 +440,18 @@ class SSWorld(World):
             for i in range(self.multiworld.players)
         ]
 
+        # seed_name on web adds an additional 'W', making the seed 21 characters long.
+        if 'W' in multiworld.seed_name:
+            ap_seed = multiworld.seed_name[1:]
+        else:
+            ap_seed = multiworld.seed_name
+
         # Output seed name and slot number to seed RNG in randomizer client.
         output_data = {
             "AP Version": list(AP_VERSION),
             "World Version": list(WORLD_VERSION),
             "Hash": f"AP P{player} " + " ".join(player_hash),
-            "AP Seed": multiworld.seed_name,
+            "AP Seed": ap_seed,
             "Rando Seed": self.random.randint(
                 0, 2**32 - 1
             ),


### PR DESCRIPTION
AP recently changed some generic options to use counters instead of dicts.... but yaml.safe_dump does not actually know how to serialize counters, which means the generate_output call is broken with latest master.
Since options support with yaml.safe_dump is not part of the AP core spec, they demand worlds to fix it.

This should do it by adding a new subclass of yaml.SafeDumper with support for counter.


In additon, for full web support: normalize the seed name between local and web gen to not cause issues with the patcher.

