### PR TITLE
restrict sword placements on Sword Dungeon Rewards

### DIFF
--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -341,6 +341,9 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
     # Sword Dungeon Reward
     if options.sword_dungeon_reward != "none":
         num_swords_to_place = pool.count("Progressive Sword")
+        if num_swords_to_place in(5,6):
+            cap = 5 if "Lanayru Mining Facility" in world.dungeons.required_dungeons or options.sword_dungeon_reward == "heart_container" else 4
+            num_swords_to_place = min(num_swords_to_place, cap)
         if num_swords_to_place < len(world.dungeons.required_dungeons):
             # More dungeons than swords to place, place as many as possible
             dungeons_to_place_swords = world.random.sample(


### PR DESCRIPTION
Restrict sword placements on Sword Dungeon Rewards to avoid unbeatable seeds due to inaccessible swords


## What is this fixing or adding?


## How was this tested?
running fuzzer to see if the amount of fails decrease and are unrelated to this option

## If this makes graphical changes, please attach screenshots.
