### PR TITLE
SS: Fix dowsing bug with multi-classified items

### DIFF
--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 
 import yaml
 
-from BaseClasses import MultiWorld, Region, Tutorial, LocationProgressType
+from BaseClasses import MultiWorld, Region, Tutorial, LocationProgressType, ItemClassification as IC
 from Options import Toggle, OptionError
 from worlds.AutoWorld import WebWorld, World
 from worlds.Files import APContainer, AutoPatchRegister
@@ -242,6 +242,24 @@ class SSWorld(World):
                 )
 
         return progress_locations, nonprogress_locations
+    
+    @staticmethod
+    def _get_classification_name(classification: IC) -> str:
+        """
+        Return a string representation of the item's highest-order classification.
+        :param classification: The item's classification.
+        :return: A string representation of the item's highest classification. The order of classification is
+        progression > trap > useful > filler.
+        """
+
+        if IC.progression in classification:
+            return "progression"
+        elif IC.trap in classification:
+            return "trap"
+        elif IC.useful in classification:
+            return "useful"
+        else:
+            return "filler"
 
     def generate_early(self) -> None:
         """
@@ -490,7 +508,7 @@ class SSWorld(World):
                         "player": location.item.player,
                         "name": location.item.name,
                         "game": location.item.game,
-                        "classification": location.item.classification.name,
+                        "classification": SSWorld._get_classification_name(location.item.classification),
                     }
                 else:
                     print(


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug that caused items with multiple classifications (i.e., progression & useful) to not ping in chests. Instead of directly passing in the classification name, it checks first for progression, then trap, then useful, then filler.


## How was this tested?
I generated a multiworld with Twilight Princess and Skyward Sword. Progressive Hidden Skill and Iron Boots (the two offending items found when this bug was discovered) were correctly classed as pinging items.