### PR TITLE
Add console connection support

### DIFF
--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -1,8 +1,12 @@
 import asyncio
 import copy
+from dataclasses import dataclass
 import time
 import traceback
 import textwrap
+import socket
+import struct
+import threading
 from typing import TYPE_CHECKING, Any, List, Optional
 
 import dolphin_memory_engine
@@ -26,6 +30,343 @@ from .SSClientUtils import *
 if TYPE_CHECKING:
     import kvui
 
+class AsyncUDPProtocol(asyncio.DatagramProtocol):
+    def __init__(self, client):
+        self.client: AsyncWiiMemoryClient = client
+        
+    def datagram_received(self, data, addr):
+        self.client.handle_response(data)
+    
+    def error_received(self, exc):
+        print(f"UDP error: {exc}")
+        self.client.established = False
+
+class CommandRequest:
+    def __init__(self, command: bytes, timeout: float = 10.0):
+        self.command = command
+        self.timeout = timeout
+        self.future = asyncio.Future()
+        self.timestamp = time.time()
+
+class AsyncWiiMemoryClient:
+    def __init__(self, wii_ip, port=43673, min_delay_ms=5):
+        self.wii_ip = wii_ip
+        self.port = port
+        self.min_delay_ms = min_delay_ms
+        self.transport = None
+        self.protocol = None
+        self.established = False
+        
+        # Queue for UDP queries to the wii
+        self.command_queue = asyncio.Queue()
+        self.current_request: Optional[CommandRequest] = None
+        self.last_command_time = 0.0
+        self.queue_processor_task = None
+        
+    async def connect(self):
+        """Establish connection to Wii"""
+        try:
+            loop = asyncio.get_event_loop()
+            self.transport, self.protocol = await loop.create_datagram_endpoint(
+                lambda: AsyncUDPProtocol(self),
+                remote_addr=(self.wii_ip, self.port)
+            )
+            sock = self.transport.get_extra_info('socket')
+            self.my_ip = sock.getsockname()[0]
+            self.my_port = sock.getsockname()[1]
+
+            self.queue_processor_task = asyncio.create_task(self._process_command_queue())
+            
+            # Send IP / port info so the Wii can write back
+            try:
+                await self.establish_connection()
+                self.established = True
+                return True
+            except asyncio.TimeoutError:
+                self.established = False
+                return False
+                
+        except Exception as e:
+            print(f"Connection failed: {e}")
+            self.established = False
+            return False
+
+    async def disconnect(self):
+        if self.queue_processor_task:
+            self.queue_processor_task.cancel()
+            try:
+                await self.queue_processor_task
+            except asyncio.CancelledError:
+                pass
+        
+        if self.transport:
+            self.transport.close()
+            
+        self.established = False
+
+    async def establish_connection(self, timeout=1):
+        """Send a packet with IP and Port to establish connection to Wii server"""
+        command = b'\x00' + socket.inet_aton(self.my_ip) + struct.pack('>H', self.my_port)
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) > 0:
+            return True
+        else:
+            raise Exception(f"Establishing UDP connection failed")
+    
+    async def _send_command_queued(self, command: bytes, timeout=2):
+        """Queue up command to read/write to console"""
+            
+        request = CommandRequest(command, timeout)
+        await self.command_queue.put(request)
+        
+        try:
+            # Wait for wii's response
+            response = await asyncio.wait_for(request.future, timeout=timeout)
+            return response
+        except asyncio.TimeoutError:
+            print(f"Command {command} timed out")
+            self.established = False
+            raise
+
+    async def _process_command_queue(self):
+        """Process commands from queue with rate limiting"""
+        while True:
+            try:
+                request = await self.command_queue.get()
+                
+                # Find out how long to wait before sending request to wii
+                current_time = time.time()
+                time_since_last = current_time - self.last_command_time
+                min_delay_seconds = self.min_delay_ms / 1000.0
+                
+                if time_since_last < min_delay_seconds:
+                    wait_time = min_delay_seconds - time_since_last
+                    await asyncio.sleep(wait_time)
+                
+                # Send command to wii
+                if self.transport and not request.future.cancelled():
+                    self.current_request = request
+                    self.transport.sendto(request.command)
+                    self.last_command_time = time.time()
+                    
+                    asyncio.create_task(self._handle_request_timeout(request))
+                elif request.future and not request.future.cancelled():
+                    # Connection lost, cancel the request
+                    request.future.set_exception(ConnectionError("Not connected"))
+                    
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                print(f"Error in command queue: {e}")
+                if self.current_request and not self.current_request.future.cancelled():
+                    self.current_request.future.set_exception(e)
+
+    async def _handle_request_timeout(self, request: CommandRequest):
+        """Handle timeout for a specific request"""
+        try:
+            await asyncio.sleep(request.timeout)
+            if self.current_request == request and not request.future.done():
+                request.future.set_exception(asyncio.TimeoutError())
+                self.current_request = None
+        except asyncio.CancelledError:
+            pass
+
+    def handle_response(self, data):
+        """Handle incoming UDP response"""
+        if self.current_request and not self.current_request.future.done():
+            self.current_request.future.set_result(data)
+            self.current_request = None
+        else:
+            print(f"Received unexpected response: {data}")
+
+    async def read_bytes(self, address, length, timeout=2):
+        """Read bytes from memory address"""
+        command = struct.pack('>BII', 0x01, address, length)  # READ - 0x01
+        # The wii will validate that this sum mod 256 is correct
+        checksum = sum(command) & 0xFF
+        command += checksum.to_bytes(1, 'big')
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) == length:
+            return response
+        else:
+            raise Exception(f"Read failed at address 0x{address:08x}")
+    
+    async def write_bytes(self, address, data, timeout=2):
+        """Write bytes to memory address"""
+        command = struct.pack('>BII', 0x02, address, len(data)) + data  # WRITE - 0x02
+        # The wii will validate that this sum mod 256 is correct
+        checksum = sum(command) & 0xFF
+        command += checksum.to_bytes(1, 'big')
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) == 1:
+            return True
+        else:
+            raise Exception(f"Write failed at address 0x{address:08x}")
+    
+    async def get_scene_flags(self, timeout=2) -> bytes:
+        """Get all scene flags at once"""
+        command = struct.pack('>B', 0x03)  # GET_SCENE_FLAGS - 0x03
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) > 0:
+            return response
+        else:
+            raise Exception(f"Sceneflag read failed.")
+    
+    async def get_story_flags(self, timeout=2) -> bytes:
+        """Get all storyflags at once"""
+        command = struct.pack('>B', 0x04)  # GET_STORY_FLAGS - 0x03
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) > 0:
+            return response
+        else:
+            raise Exception(f"Storyflag read failed")
+    
+    async def signal_dc(self, timeout=2) -> bytes:
+        """Send a signal to the Wii that a packet was lost"""
+        command = struct.pack('>B', 0x05)  # DISCONNECT - 0x05
+        
+        response = await self._send_command_queued(command, timeout)
+        
+        if len(response) > 0:
+            return response
+        else:
+            raise Exception(f"Read failed at address")
+    
+    def close(self):
+        """Close connection"""
+        self.established = False
+        if self.transport:
+            self.transport.close()
+            self.transport = None
+
+@dataclass
+class BatchFlagHandler:
+    flags: bytes
+    base_addr: int
+    def lookup_byte(self, addr: int) -> int:
+        offset = addr - self.base_addr
+        assert(offset >= 0)
+        return self.flags[offset]
+
+class WiiMemoryClient:
+    def __init__(self, wii_ip, port=43673):
+        self.wii_ip = wii_ip
+        self.port = port
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(5.0)  # 5 second timeout
+        self.sock.connect((self.wii_ip, self.port))
+        self.my_ip, self.my_port = self.sock.getsockname()
+        self.established = False
+        
+    def close(self):
+        self.sock.close()
+
+    def establish_connection(self):
+        """adfsdfa"""
+        # Command format: 0x00 - [4 addr bytes] - [4 bytes for num to read]
+        command = b'\x03' + socket.inet_aton(self.my_ip) + struct.pack('>H', self.my_port)
+        
+        try:
+            # Send command
+            self.sock.send(command)
+            
+            # Receive response
+            response, addr = self.sock.recvfrom(1024)
+            # print(f"Read {len(response)} bytes from address")
+            self.established = True
+            return response
+            
+        except socket.timeout:
+            print(f"Timeout reading from address")
+            return None
+        except Exception as e:
+            print(f"Error reading memory: {e}")
+            return None
+        
+    def read_memory(self, address, num_bytes):
+        """Read bytes from Wii memory at specified address"""
+        # Command format: 0x00 - [4 addr bytes] - [4 bytes for num to read]
+        command = struct.pack('>BII', 0, address, num_bytes)
+        
+        try:
+            # Send command
+            self.sock.send(command)
+            
+            # Receive response
+            response, addr = self.sock.recvfrom(1024)
+            # print(f"Read {len(response)} bytes from address 0x{address:08x}")
+            return response
+            
+        except socket.timeout:
+            print(f"Timeout reading from address 0x{address:08x}")
+            return None
+        except Exception as e:
+            print(f"Error reading memory: {e}")
+            return None
+    
+    def write_memory(self, address, data):
+        """Write bytes to Wii memory at specified address"""
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        elif isinstance(data, int):
+            data = struct.pack('>I', data)  # Convert int to 4 bytes
+            
+        # Command format: 0x01 - [4 addr bytes] - [4 bytes for num to write] - [contents]
+        command = struct.pack('>BII', 1, address, len(data)) + data
+        
+        try:
+            # Send command
+            self.sock.send(command)
+            
+            # Receive acknowledgment
+            response, addr = self.sock.recvfrom(1024)
+            if len(response) == 1 and response[0] == 0:
+                print(f"Successfully wrote {len(data)} bytes to address 0x{address:08x}")
+                return True
+            else:
+                print(f"Unexpected response: {response}")
+                return False
+                
+        except socket.timeout:
+            print(f"Timeout writing to address 0x{address:08x}")
+            return False
+        except Exception as e:
+            print(f"Error writing memory: {e}")
+            return False
+    
+    def write_memory(self, address, bytes: bytes):
+        # Command format: 0x01 - [4 addr bytes] - [4 bytes for num to write] - [contents]
+        command = struct.pack('>BII', 1, address, len(bytes)) + bytes
+        
+        try:
+            # Send command
+            self.sock.send(command)
+            
+            # Receive acknowledgment
+            response, addr = self.sock.recvfrom(1024)
+            if len(response) == 1 and response[0] == 0:
+                # print(f"Successfully wrote {len(bytes)} bytes to address 0x{address:08x}")
+                return True
+            else:
+                print(f"Unexpected response: {response}")
+                return False
+                
+        except socket.timeout:
+            print(f"Timeout writing to address 0x{address:08x}")
+            return False
+        except Exception as e:
+            print(f"Error writing memory: {e}")
+            return False
 
 class SSCommandProcessor(ClientCommandProcessor):
     """
@@ -42,11 +383,21 @@ class SSCommandProcessor(ClientCommandProcessor):
 
     def _cmd_dolphin(self) -> None:
         """
-        Display the current Dolphin emulator connection status.
+        Switch to Dolphin mode and display the current Dolphin emulator connection status.
         """
         if isinstance(self.ctx, SSContext):
             logger.info(f"Dolphin Status: {self.ctx.dolphin_status}")
-
+            self.ctx.on_console = False
+    
+    def _cmd_console(self, ip_addr: str) -> None:
+        """
+        Switch to console mode, connecting to a UDP server on a Wii (must be on the same network)
+        """
+        if isinstance(self.ctx, SSContext):
+            logger.info(f"Starting up a Wii client...")
+            self.ctx.wii_ip = ip_addr
+            self.ctx.on_console = True
+            self.ctx.start_wii_client(ip_addr)
 
 class SSContext(CommonContext):
     """
@@ -69,7 +420,7 @@ class SSContext(CommonContext):
 
         super().__init__(server_address, password)
         self.items_rcvd: list[tuple[NetworkItem, int]] = []
-        self.dolphin_sync_task: Optional[asyncio.Task[None]] = None
+        self.sync_task: Optional[asyncio.Task[None]] = None
         self.dolphin_status: str = CONNECTION_INITIAL_STATUS
         self.awaiting_rom: bool = False
         self.last_rcvd_index: int = -1
@@ -82,6 +433,14 @@ class SSContext(CommonContext):
 
         self.ingame_client_messages: list[tuple[float, str]] = []
         self.text_buffer_address: int = 0x0 # will be read from the dol when connected
+        self.link_ptr: int = 0x0 # will be read from the dol when connected
+        self.link_state: bytes = b'\x00\x00\x00'
+        self.link_action: int = 0
+        self.on_console: bool = False
+        self.wii_memory_client: AsyncWiiMemoryClient = None
+        self.wii_ip: str = "0.0.0.0"
+        self.socket = None # Server socket
+        self.client_socket = None # Connection from Wii
 
         # Name of the current stage as read from the game's memory. Sent to trackers whenever its value changes to
         # facilitate automatically switching to the map of the current stage.
@@ -122,7 +481,7 @@ class SSContext(CommonContext):
             if self.awaiting_rom:
                 return
             self.awaiting_rom = True
-            logger.info("Awaiting connection to Dolphin to get player information.")
+            logger.info("Awaiting connection to the game to get player information.")
             return
         await self.send_connect()
 
@@ -177,14 +536,14 @@ class SSContext(CommonContext):
                         )
                     self.visited_stage_names = visited_stage_names
 
-    def on_deathlink(self, data: dict[str, Any]) -> None:
+    async def on_deathlink(self, data: dict[str, Any]) -> None:
         """
         Handle a DeathLink event.
 
         :param data: The data associated with the DeathLink event.
         """
         super().on_deathlink(data)
-        _give_death(self)
+        await self._give_death(self)
 
     def make_gui(self) -> type["kvui.GameManager"]:
         """
@@ -239,7 +598,7 @@ class SSContext(CommonContext):
                 (timestamp + len(self.ingame_client_messages) * 0.5, line)
             )
 
-    def show_messages_ingame(self) -> None:
+    async def show_messages_ingame(self) -> None:
         # Filter out old messages
         line_list = []
         filtered_msgs = []
@@ -254,11 +613,11 @@ class SSContext(CommonContext):
         self.ingame_client_messages = filtered_msgs
 
         if len(line_list) == 0:
-            self.write_string_to_buffer("")
+            await self.write_string_to_buffer("")
         else:
             # Want to cap it at 16 lines so the text doesn't get too obtrusive
             # (which could happen if each line is quite short)
-            self.write_string_to_buffer("\n".join(line_list[:16]))
+            await self.write_string_to_buffer("\n".join(line_list[:16]))
 
     def on_print_json(self, args: dict):
         # Don't show messages in-game for item sends irrelevant to this slot
@@ -269,425 +628,498 @@ class SSContext(CommonContext):
 
         super().on_print_json(args)
     
-    def write_string_to_buffer(self, text: str):
+    async def write_string_to_buffer(self, text: str):
         if self.text_buffer_address != 0x0:
             # Truncate text to fit in the buffer, then write to buffer
             text_bytes = text.encode("utf-8")[: CLIENT_TEXT_BUFFER_SIZE - 1].ljust(
                 CLIENT_TEXT_BUFFER_SIZE, b"\x00"
             )
-            dolphin_memory_engine.write_bytes(self.text_buffer_address, text_bytes)
+            await self.write_bytes(self.text_buffer_address, text_bytes)
+    
+    def start_wii_client(self, ip):
+        """Initialize the async Wii client"""
+        if self.wii_memory_client:
+            self.wii_memory_client.close()
+        self.wii_memory_client = AsyncWiiMemoryClient(ip)
+    
+    def close_wii_client(self):
+        """Close Wii client connection"""
+        if self.wii_memory_client:
+            self.wii_memory_client.close()
+            self.wii_memory_client = None
+    
+    def is_hooked(self):
+        if self.on_console:
+            return self.wii_memory_client and self.wii_memory_client.established
+        
+        return dolphin_memory_engine.is_hooked() and self.dolphin_status == CONNECTION_CONNECTED_STATUS
+
+    async def read_bytes(self, console_address: int, num_bytes: int) -> bytes:
+        """
+        Read bytes from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        if self.on_console:
+            return await self.wii_memory_client.read_bytes(console_address, num_bytes)
+
+        return dolphin_memory_engine.read_bytes(console_address, num_bytes)
+    
+    async def write_bytes(self, console_address: int, to_write: bytes):
+        """
+        Write bytes to the game's memory
+
+        :param console_address: Address to write to.
+        :param to_write: Bytes to write
+        """
+        if self.on_console:
+            await self.wii_memory_client.write_bytes(console_address, to_write)
+            return
+            command = struct.pack('>BII', 0x01, console_address, len(to_write)) + to_write
+            self.client_socket.send(command)
+
+            self.client_socket.recv(1)
+            return
+            
+        dolphin_memory_engine.write_bytes(console_address, to_write)
+
+    async def read_byte(self, console_address: int) -> int:
+        """
+        Read 1 byte from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        bytes = await self.read_bytes(console_address, 1)
+        return int.from_bytes(bytes, byteorder='big')
+
+    async def read_short(self, console_address: int) -> int:
+        """
+        Read a 2-byte short from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        bytes = await self.read_bytes(console_address, 2)
+        return int.from_bytes(bytes, byteorder='big')
+
+    async def read_long(self, console_address: int) -> int:
+        """
+        Read a 4-byte long from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        bytes = await self.read_bytes(console_address, 4)
+        return int.from_bytes(bytes, byteorder='big')
+    
+    async def write_byte(self, console_address: int, value: int) -> None:
+        """
+        Write a byte to the game's memory
+
+        :param console_address: Address to write to.
+        :param value: Value to write.
+        """
+        await self.write_bytes(
+            console_address, value.to_bytes(1, byteorder="big")
+        )
+    
+    async def write_short(self, console_address: int, value: int) -> None:
+        """
+        Write a 2-byte short to the game's memory
+
+        :param console_address: Address to write to.
+        :param value: Value to write.
+        """
+        await self.write_bytes(
+            console_address, value.to_bytes(2, byteorder="big")
+        )
+    
+    async def read_string(self, console_address: int, strlen: int) -> str:
+        """
+        Read a string from the game's memory.
+
+        :param console_address: Address to start reading from.
+        :param strlen: Length of the string to read.
+        :return: The string.
+        """
+        strbytes = await self.read_bytes(console_address, strlen)
+        return (
+            strbytes
+            .split(b"\0", 1)[0]
+            .decode()
+        )
+    
+    async def read_slot(self) -> str:
+        """
+        Read the slot name from the game's memory
+        Slot name is 16 bytes, offset 20 bytes from the AP array.
+        Slot name is encoded in UTF-8.
+
+        :return: The string containing the slot name.
+        """
+        slot_bytes = await self.read_bytes(ARCHIPELAGO_ARRAY_ADDR + 0x14, 0x10)
+        slot_bytes = slot_bytes.replace(b"\xFF", b"")
+
+        return slot_bytes.decode("utf-8")
+
+    async def read_scene_flags(self) -> bytes:
+        """
+        Read bytes from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        if self.on_console:
+            return await self.wii_memory_client.get_scene_flags()
+
+        return dolphin_memory_engine.read_bytes(SCENEFLAG_START_ADDR, 416)
+
+    async def read_story_flags(self) -> bytes:
+        """
+        Read bytes from the game's memory
+
+        :param console_address: Address to read from.
+        :return: The value read from memory.
+        """
+        if self.on_console:
+            return await self.wii_memory_client.get_story_flags()
+
+        return dolphin_memory_engine.read_bytes(STORYFLAG_START_ADDR, 256)
+
+    async def _give_death(self) -> None:
+        """
+        Trigger the player's death in-game by setting their current health to zero.
+        """
+        if (
+            self.slot is not None
+            and self.is_hooked()
+            and self.check_ingame()
+            and not await self.check_in_minigame()
+        ):
+            self.has_send_death = True
+            await self.write_short(CURR_HEALTH_ADDR, 0)
 
 
-def dme_read_byte(console_address: int) -> int:
-    """
-    Read 1 byte from Dolphin memory.
+    async def _give_item(self, item_name: str) -> bool:
+        """
+        Give an item to the player in-game.
 
-    :param console_address: Address to read from.
-    :return: The value read from memory.
-    """
-    return dolphin_memory_engine.read_byte(console_address)
+        :param ctx: The SS client context.
+        :param item_name: Name of the item to give.
+        :return: Whether the item was successfully given.
+        """
+        if not await self.can_receive_items():
+            return False
 
+        item_id = ITEM_TABLE[item_name].item_id  # In game item ID
 
-def dme_write_byte(console_address: int, value: bytes) -> None:
-    """
-    Write 1 byte to Dolphin memory.
+        # Loop through the item array, placing the item in an empty slot (0xFF).
+        for idx in range(self.len_give_item_array):
+            slot = await self.read_byte(ARCHIPELAGO_ARRAY_ADDR + idx)
+            if slot == 0xFF:
+                # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
+                await self.write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, item_id)
+                await asyncio.sleep(0.25)
+                await self.cache_link_data() # Recalculate State & Action
+                # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
+                # or bed which could delete the item, so we should check for a reload
+                while self.is_link_not_in_action([ITEM_GET_ACTION]):
+                    await asyncio.sleep(0.2)
+                    await self.cache_link_data() # Recalculate State & Action
+                    # While the client won't initiate an item send while the player is swimming, the player
+                    # can still receive items underwater if they're sent one just before entering the water.
+                    # The patched game *will* still give them the item, but it won't put them in the item action,
+                    # so we shouldn't resend the item, or else it will be duplicated.
+                    if self.is_link_in_action(SWIM_ACTIONS):
+                        break
+                    # If state is 0, that means a reload occurred, so we should resend the item.
+                    # However, we shouldn't resend the item if the user immediately enters the item get action anyway
+                    # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
+                    if not self.check_ingame():
+                        # Reset the value at this array index to 0, to avoid duplicating the item if it was never read in the first place
+                        await self.write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, 0xFF)
+                        debug_text = f"DEBUG: A reload deleted {self.player_names[self.slot]}'s {item_name} (ID {item_id}). Resending the item..."
+                        logger.info(debug_text)
+                        self.forward_client_message(debug_text)
+                        return False
+                return True
 
-    :param console_address: Address to write to.
-    :param value: Value to write.
-    """
-    dolphin_memory_engine.write_byte(console_address, value)
-
-
-def dme_read_short(console_address: int) -> int:
-    """
-    Read a 2-byte short from Dolphin memory.
-
-    :param console_address: Address to read from.
-    :return: The value read from memory.
-    """
-    return int.from_bytes(
-        dolphin_memory_engine.read_bytes(console_address, 2), byteorder="big"
-    )
-
-def dme_read_long(console_address: int) -> int:
-    """
-    Read a 4-byte long from Dolphin memory.
-
-    :param console_address: Address to read from.
-    :return: The value read from memory.
-    """
-    return int.from_bytes(
-        dolphin_memory_engine.read_bytes(console_address, 4), byteorder="big"
-    )
-
-
-def dme_write_short(console_address: int, value: int) -> None:
-    """
-    Write a 2-byte short to Dolphin memory.
-
-    :param console_address: Address to write to.
-    :param value: Value to write.
-    """
-    dolphin_memory_engine.write_bytes(
-        console_address, value.to_bytes(2, byteorder="big")
-    )
-
-
-def dme_read_string(console_address: int, strlen: int) -> str:
-    """
-    Read a string from Dolphin memory.
-
-    :param console_address: Address to start reading from.
-    :param strlen: Length of the string to read.
-    :return: The string.
-    """
-    return (
-        dolphin_memory_engine.read_bytes(console_address, strlen)
-        .split(b"\0", 1)[0]
-        .decode()
-    )
-
-def dme_read_slot() -> str:
-    """
-    Read the slot name from dolphin memory.
-    Slot name is 16 bytes, offset 20 bytes from the AP array.
-    Slot name is encoded in UTF-8.
-
-    :return: The string containing the slot name.
-    """
-    slot_bytes = dolphin_memory_engine.read_bytes(ARCHIPELAGO_ARRAY_ADDR + 0x14, 0x10)
-    slot_bytes = slot_bytes.replace(b"\xFF", b"")
-
-    return slot_bytes.decode("utf-8")
-
-
-
-def _give_death(ctx: SSContext) -> None:
-    """
-    Trigger the player's death in-game by setting their current health to zero.
-
-    :param ctx: The SS client context.
-    """
-    if (
-        ctx.slot is not None
-        and dolphin_memory_engine.is_hooked()
-        and ctx.dolphin_status == CONNECTION_CONNECTED_STATUS
-        and check_ingame(get_link_ptr())
-        and not check_in_minigame()
-    ):
-        ctx.has_send_death = True
-        dme_write_short(CURR_HEALTH_ADDR, 0)
-
-
-async def _give_item(ctx: SSContext, item_name: str) -> bool:
-    """
-    Give an item to the player in-game.
-
-    :param ctx: The SS client context.
-    :param item_name: Name of the item to give.
-    :return: Whether the item was successfully given.
-    """
-    if not can_receive_items(ctx):
+        # If unable to place the item in the array, return False.
         return False
 
-    item_id = ITEM_TABLE[item_name].item_id  # In game item ID
 
-    # Loop through the item array, placing the item in an empty slot (0xFF).
-    for idx in range(ctx.len_give_item_array):
-        slot = dme_read_byte(ARCHIPELAGO_ARRAY_ADDR + idx)
-        if slot == 0xFF:
-            # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
-            dme_write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, item_id)
-            await asyncio.sleep(0.25)
-            # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
-            # or bed which could delete the item, so we should check for a reload
-            while is_link_not_in_action(get_link_ptr(), [ITEM_GET_ACTION]):
-                await asyncio.sleep(0.1)
-                # While the client won't initiate an item send while the player is swimming, the player
-                # can still receive items underwater if they're sent one just before entering the water.
-                # The patched game *will* still give them the item, but it won't put them in the item action,
-                # so we shouldn't resend the item, or else it will be duplicated.
-                if is_link_in_action(get_link_ptr(), SWIM_ACTIONS):
-                    break
-                # If state is 0, that means a reload occurred, so we should resend the item.
-                # However, we shouldn't resend the item if the user immediately enters the item get action anyway
-                # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
-                if not check_ingame(get_link_ptr()):
-                    # Reset the value at this array index to 0, to avoid duplicating the item if it was never read in the first place
-                    dme_write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, 0xFF)
-                    debug_text = f"DEBUG: A reload deleted {ctx.player_names[ctx.slot]}'s {item_name} (ID {item_id}). Resending the item..."
-                    logger.info(debug_text)
-                    ctx.forward_client_message(debug_text)
-                    return False
+    async def give_items(self) -> None:
+        """
+        Give the player all outstanding items they have yet to receive.
+
+        :param ctx: The SS client context.
+        """
+        if await self.can_receive_items():
+            # Read the expected index of the player, which is the index of the latest item they've received.
+            expected_idx = await self.read_short(EXPECTED_INDEX_ADDR)
+
+            # Loop through items to give.
+            for item, idx in self.items_rcvd:
+                # If the item's index is greater than the player's expected index, give the player the item.
+                if expected_idx <= idx:
+                    # Attempt to give the item and increment the expected index.
+                    while not await self._give_item(LOOKUP_ID_TO_NAME[item.item]):
+                        await asyncio.sleep(0.25)
+                        await self.cache_link_data()
+
+                    # Increment the expected index.
+                    await self.write_short(EXPECTED_INDEX_ADDR, idx + 1)
+
+
+    async def check_locations(self) -> None:
+        """
+        Loops through all locations and checks the sceneflag/storyflag(s) associated with the location in the location table.
+
+        If Hylia's Realm - Defeat Demise is checked, update the server that this player has beaten the game.
+        Otherwise, send the list of checked locations to the server.
+
+        :param ctx: The SS client context.
+        """
+        # Don't send locations from the title screen (BiT)
+        if await self.can_send_items():
+            storyflags = BatchFlagHandler(await self.read_story_flags(), STORYFLAG_START_ADDR)
+            sceneflags = BatchFlagHandler(await self.read_scene_flags(), SCENEFLAG_START_ADDR)
+            # Loop through all locations to see if each has been checked.
+            for location, data in LOCATION_TABLE.items():
+                checked = False
+                [flag_type, flag_bit, flag_value, addr] = data.checked_flag
+                if flag_type == SSLocCheckedFlag.STORY:
+                    flag = storyflags.lookup_byte(addr + flag_bit)
+                    checked = bool(flag & flag_value)
+                elif flag_type == SSLocCheckedFlag.SCENE:
+                    flag = sceneflags.lookup_byte(STAGE_TO_SCENEFLAG_ADDR[addr] + flag_bit)
+                    checked = bool(flag & flag_value)
+                elif flag_type == SSLocCheckedFlag.SPECL:
+                    if location == "Upper Skyloft - Ghost/Pipit's Crystals":
+                        byte = await self.read_byte(0x805A9B16)
+                        flag1 = bool(byte & 0x80)  # 5 crystals from Pipit
+                        flag2 = bool(byte & 0x04)  # 5 crystals from Ghost
+                        checked = flag1 or flag2
+                    if location == "Central Skyloft - Peater/Peatrice's Crystals":
+                        bytelong = await self.read_long(0x805A9B1A)
+                        flag1 = bool(
+                            bytelong & 0x40000000
+                        )  # 5 crystals from Peatrice
+                        flag2 = bool(bytelong & 0x02)  # 5 crystals from Peater
+                        checked = flag1 or flag2
+
+                if checked:
+                    if data.code is None:  # Defeat Demise
+                        if not self.finished_game:
+                            await self.send_msgs(
+                                [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
+                            )
+                            self.finished_game = True
+                    else:
+                        self.locations_checked.add(SSLocation.get_apid(data.code))
+                        for slot, checks in enumerate(BEEDLE_CHECKS):
+                            if self.beedle_items_purchased[slot] < len(BEEDLE_CHECKS[slot]) - 1:
+                                self.beedle_items_purchased[slot] += (data.code == checks[self.beedle_items_purchased[slot]])
+                                
+            
+            for hint, data in HINT_TABLE.items():
+                [flag_bit, flag_value, addr] = data.checked_flag
+                # All hint flags are story flags
+                flag = storyflags.lookup_byte(addr + flag_bit)
+                checked = bool(flag & flag_value)
+
+                if checked or self.finished_game:
+                    for locname in self.locations_for_hint.get(hint, []):
+                        self.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
+
+            # Send the list of newly-checked locations & hints to the server.
+            locations_checked = self.locations_checked.difference(self.checked_locations)
+            hints_checked = self.hints_checked.difference(self.checked_hints)
+            if locations_checked:
+                await self.send_msgs([{"cmd": "LocationChecks", "locations": locations_checked}]) 
+            if hints_checked:
+                await self.send_msgs([{"cmd": "LocationScouts", "locations": hints_checked, "create_as_hint": 2}])
+
+            self.checked_hints |= hints_checked
+
+
+    async def check_current_stage_changed(self) -> None:
+        """
+        Check if the player has moved to a new stage.
+        If so, update all trackers with the new stage name.
+        If the stage has never been visited, additionally update the server.
+
+        :param ctx: The SS client context.
+        """
+        new_stage_name = await self.read_string(CURR_STAGE_ADDR, 16)
+
+        current_stage_name = self.current_stage_name
+
+        if new_stage_name != current_stage_name:
+            if new_stage_name == BEEDLE_STAGE:
+                await self.scout_beedle_checks()
+            self.current_stage_name = new_stage_name
+            # Send a Bounced message containing the new stage name to all trackers connected to the current slot.
+            data_to_send = {"ss_stage_name": new_stage_name}
+            message = {
+                "cmd": "Bounce",
+                "slots": [self.slot],
+                "data": data_to_send,
+            }
+            await self.send_msgs([message])
+
+            # If the stage has never been visited before, update the server's data storage to indicate that it has been
+            # visited.
+            visited_stage_names = self.visited_stage_names
+            if (
+                visited_stage_names is not None
+                and new_stage_name not in visited_stage_names
+            ):
+                visited_stage_names.add(new_stage_name)
+                await self.update_visited_stages(new_stage_name)
+
+    async def scout_beedle_checks(self) -> None:
+        locs_to_scout = set()
+        for slot, purchased_idx in enumerate(self.beedle_items_purchased):
+            if len(BEEDLE_CHECKS[slot]) > purchased_idx:
+                locs_to_scout.add(SSLocation.get_apid(BEEDLE_CHECKS[slot][purchased_idx]))
+        
+        await self.send_msgs([{"cmd": "LocationScouts", "locations": locs_to_scout, "create_as_hint": 2}]) 
+
+    async def check_alive(self) -> bool:
+        """
+        Check if the player is currently alive in-game.
+
+        :return: `True` if the player is alive, otherwise `False`.
+        """
+        cur_health = await self.read_short(CURR_HEALTH_ADDR)
+        return cur_health > 0
+
+
+    async def check_death(self) -> None:
+        """
+        Check if the player is currently dead in-game.
+        If DeathLink is on, notify the server of the player's death.
+
+        :return: `True` if the player is dead, otherwise `False`.
+        """
+        if self.slot is not None and self.check_ingame(self.get_link_ptr()) and not self.check_on_title_screen():
+            cur_health = await self.read_short(CURR_HEALTH_ADDR)
+            if cur_health <= 0:
+                if not self.has_send_death and time.time() >= self.last_death_link + 3:
+                    self.has_send_death = True
+                    await self.send_death(self.player_names[self.slot] + " ran out of hearts.")
+            else:
+                self.has_send_death = False
+
+    def check_ingame(self) -> bool:
+        """
+        Check if the player is currently in-game.
+
+        :return: `True` if the player is in-game, otherwise `False`.
+        """
+        return int.from_bytes(self.link_state) != 0x0
+
+    async def check_on_title_screen(self) -> bool:
+        """
+        Check if the player is on the Title Screen.
+        
+        :return: `True` if the player is on the title screen, otherwise `False`.
+        """
+        return await self.read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
+
+    async def check_in_minigame(self) -> bool:
+        """
+        Check if the player is in a minigame.
+        
+        :return: `True` if the player is in a minigame, false if not.
+        """
+        return await self.read_byte(MINIGAME_STATE_ADDR) == 0x0
+    
+    async def cache_link_data(self):
+        self.link_ptr = await self.read_long(LINK_PTR)
+        self.link_state = await self.get_link_state()
+        self.link_action = await self.get_link_action()
+
+    async def get_link_ptr(self) -> int:
+        return await self.read_long(LINK_PTR)
+
+    async def get_link_state(self) -> bytes:
+        if self.link_ptr == 0x0: return b'\x00\x00\x00'
+        return await self.read_bytes(self.link_ptr + CURR_STATE_OFFSET, 3)
+
+    async def get_link_action(self) -> int:
+        if self.link_ptr == 0x0: return 0
+        return await self.read_byte(self.link_ptr + LINK_ACTION_OFFSET)
+
+    def validate_link_state(self) -> bool:
+        """
+        Returns a bool determining whether Link is in a valid or invalid state to receive items.
+
+        :return: True if Link is in a valid state, False if Link is in an invalid state
+        """
+        if self.link_ptr == 0x0 or self.link_state in LINK_INVALID_STATES:
+            return False
+        else:
             return True
 
-    # If unable to place the item in the array, return False.
-    return False
+    def validate_link_action(self) -> bool:
+        """
+        Returns a bool determining if Link is in a safe action to receive items.
 
+        :return: True if Link is in a safe action, False if Link is not in a safe action.
+        """
+        if self.link_ptr == 0x0:
+            return False
+        return self.link_action <= MAX_SAFE_ACTION
 
-async def give_items(ctx: SSContext) -> None:
+    def is_link_not_in_action(self, actions: List[int]) -> bool:
+        if self.link_ptr == 0x0:
+            return True
+
+        return self.link_action not in actions
+
+    def is_link_in_action(self, actions: List[int]) -> bool:
+        if self.link_ptr == 0x0:
+            return False
+
+        return self.link_action in actions
+
+    async def check_on_file_1(self) -> bool:
+        """
+        Returns a bool determining if the player is currently on File 1.
+
+        :return: True if File 1 last selected, False otherwise
+        """
+        file = await self.read_byte(SELECTED_FILE_ADDR)
+        return file == 0x0
+
+    async def can_receive_items(self) -> bool:
+        """
+        Link must be on File 1 in a valid state and action and not on the title screen to receive items.
+        """
+
+        return (
+            self.link_ptr != 0x0
+            and await self.can_send_items()
+            and await self.check_alive()
+            and self.validate_link_state()
+            and self.validate_link_action()
+            and not await self.check_in_minigame()
+            and self.current_stage_name != DEMISE_STAGE
+        )
+
+    async def can_send_items(self) -> bool:
+        """
+        Link must be on File 1 and not on the tile screen to send items.
+        """
+        return (not await self.check_on_title_screen()) and await self.check_on_file_1()
+
+async def do_sync_task(ctx: SSContext) -> None:
     """
-    Give the player all outstanding items they have yet to receive.
-
-    :param ctx: The SS client context.
-    """
-    if can_receive_items(ctx):
-        # Read the expected index of the player, which is the index of the latest item they've received.
-        expected_idx = dme_read_short(EXPECTED_INDEX_ADDR)
-
-        # Loop through items to give.
-        for item, idx in ctx.items_rcvd:
-            # If the item's index is greater than the player's expected index, give the player the item.
-            if expected_idx <= idx:
-                # Attempt to give the item and increment the expected index.
-                while not await _give_item(ctx, LOOKUP_ID_TO_NAME[item.item]):
-                    await asyncio.sleep(0.25)
-
-                # Increment the expected index.
-                dme_write_short(EXPECTED_INDEX_ADDR, idx + 1)
-
-
-async def check_locations(ctx: SSContext) -> None:
-    """
-    Loops through all locations and checks the sceneflag/storyflag(s) associated with the location in the location table.
-
-    If Hylia's Realm - Defeat Demise is checked, update the server that this player has beaten the game.
-    Otherwise, send the list of checked locations to the server.
-
-    :param ctx: The SS client context.
-    """
-    # Don't send locations from the title screen (BiT)
-    if can_send_items():
-        # Loop through all locations to see if each has been checked.
-        for location, data in LOCATION_TABLE.items():
-            checked = False
-            [flag_type, flag_bit, flag_value, addr] = data.checked_flag
-            if flag_type == SSLocCheckedFlag.STORY:
-                flag = dme_read_byte(addr + flag_bit)
-                checked = bool(flag & flag_value)
-            elif flag_type == SSLocCheckedFlag.SCENE:
-                flag = dme_read_byte(STAGE_TO_SCENEFLAG_ADDR[addr] + flag_bit)
-                checked = bool(flag & flag_value)
-            elif flag_type == SSLocCheckedFlag.SPECL:
-                if location == "Upper Skyloft - Ghost/Pipit's Crystals":
-                    flag1 = bool(dme_read_byte(0x805A9B16) & 0x80)  # 5 crystals from Pipit
-                    flag2 = bool(dme_read_byte(0x805A9B16) & 0x04)  # 5 crystals from Ghost
-                    checked = flag1 or flag2
-                if location == "Central Skyloft - Peater/Peatrice's Crystals":
-                    flag1 = bool(
-                        dme_read_byte(0x805A9B1A) & 0x40
-                    )  # 5 crystals from Peatrice
-                    flag2 = bool(dme_read_byte(0x805A9B1D) & 0x02)  # 5 crystals from Peater
-                    checked = flag1 or flag2
-
-            if checked:
-                if data.code is None:  # Defeat Demise
-                    if not ctx.finished_game:
-                        await ctx.send_msgs(
-                            [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
-                        )
-                        ctx.finished_game = True
-                else:
-                    ctx.locations_checked.add(SSLocation.get_apid(data.code))
-                    for slot, checks in enumerate(BEEDLE_CHECKS):
-                        if ctx.beedle_items_purchased[slot] < len(BEEDLE_CHECKS[slot]) - 1:
-                            ctx.beedle_items_purchased[slot] += (data.code == checks[ctx.beedle_items_purchased[slot]])
-                            
-        
-        for hint, data in HINT_TABLE.items():
-            [flag_bit, flag_value, addr] = data.checked_flag
-            # All hint flags are story flags
-            flag = dme_read_byte(addr + flag_bit)
-            checked = bool(flag & flag_value)
-
-            if checked or ctx.finished_game:
-                for locname in ctx.locations_for_hint.get(hint, []):
-                    ctx.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
-
-        # Send the list of newly-checked locations & hints to the server.
-        locations_checked = ctx.locations_checked.difference(ctx.checked_locations)
-        hints_checked = ctx.hints_checked.difference(ctx.checked_hints)
-        if locations_checked:
-            await ctx.send_msgs([{"cmd": "LocationChecks", "locations": locations_checked}]) 
-        if hints_checked:
-            await ctx.send_msgs([{"cmd": "LocationScouts", "locations": hints_checked, "create_as_hint": 2}])
-
-        ctx.checked_hints |= hints_checked
-
-
-async def check_current_stage_changed(ctx: SSContext) -> None:
-    """
-    Check if the player has moved to a new stage.
-    If so, update all trackers with the new stage name.
-    If the stage has never been visited, additionally update the server.
-
-    :param ctx: The SS client context.
-    """
-    new_stage_name = dme_read_string(CURR_STAGE_ADDR, 16)
-
-    current_stage_name = ctx.current_stage_name
-
-    if new_stage_name != current_stage_name:
-        if new_stage_name == BEEDLE_STAGE:
-            await scout_beedle_checks(ctx)
-        ctx.current_stage_name = new_stage_name
-        # Send a Bounced message containing the new stage name to all trackers connected to the current slot.
-        data_to_send = {"ss_stage_name": new_stage_name}
-        message = {
-            "cmd": "Bounce",
-            "slots": [ctx.slot],
-            "data": data_to_send,
-        }
-        await ctx.send_msgs([message])
-
-        # If the stage has never been visited before, update the server's data storage to indicate that it has been
-        # visited.
-        visited_stage_names = ctx.visited_stage_names
-        if (
-            visited_stage_names is not None
-            and new_stage_name not in visited_stage_names
-        ):
-            visited_stage_names.add(new_stage_name)
-            await ctx.update_visited_stages(new_stage_name)
-
-async def scout_beedle_checks(ctx: SSContext) -> None:
-    locs_to_scout = set()
-    for slot, purchased_idx in enumerate(ctx.beedle_items_purchased):
-        if len(BEEDLE_CHECKS[slot]) > purchased_idx:
-            locs_to_scout.add(SSLocation.get_apid(BEEDLE_CHECKS[slot][purchased_idx]))
-    
-    await ctx.send_msgs([{"cmd": "LocationScouts", "locations": locs_to_scout, "create_as_hint": 2}]) 
-
-def check_alive() -> bool:
-    """
-    Check if the player is currently alive in-game.
-
-    :return: `True` if the player is alive, otherwise `False`.
-    """
-    cur_health = dme_read_short(CURR_HEALTH_ADDR)
-    return cur_health > 0
-
-
-async def check_death(ctx: SSContext) -> None:
-    """
-    Check if the player is currently dead in-game.
-    If DeathLink is on, notify the server of the player's death.
-
-    :return: `True` if the player is dead, otherwise `False`.
-    """
-    if ctx.slot is not None and check_ingame(get_link_ptr()) and not check_on_title_screen():
-        cur_health = dme_read_short(CURR_HEALTH_ADDR)
-        if cur_health <= 0:
-            if not ctx.has_send_death and time.time() >= ctx.last_death_link + 3:
-                ctx.has_send_death = True
-                await ctx.send_death(ctx.player_names[ctx.slot] + " ran out of hearts.")
-        else:
-            ctx.has_send_death = False
-
-def check_ingame(link_ptr: int) -> bool:
-    """
-    Check if the player is currently in-game.
-
-    :return: `True` if the player is in-game, otherwise `False`.
-    """
-    if link_ptr == 0x0:
-        return False
-    return int.from_bytes(get_link_state(link_ptr)) != 0x0
-
-def check_on_title_screen() -> bool:
-    """
-    Check if the player is on the Title Screen.
-    
-    :return: `True` if the player is on the title screen, otherwise `False`.
-    """
-    return dme_read_byte(GLOBAL_TITLE_LOADER_ADDR) != 0x0
-
-def check_in_minigame() -> bool:
-    """
-    Check if the player is in a minigame.
-    
-    :return: `True` if the player is in a minigame, false if not.
-    """
-    return dme_read_byte(MINIGAME_STATE_ADDR) == 0x0
-
-def get_link_ptr() -> int:
-    return dolphin_memory_engine.read_word(LINK_PTR)
-
-def get_link_state(link_ptr: int) -> bytes:
-    return dolphin_memory_engine.read_bytes(link_ptr + CURR_STATE_OFFSET, 3)
-
-def get_link_action(link_ptr: int) -> int:
-    return dme_read_byte(link_ptr + LINK_ACTION_OFFSET)
-
-def validate_link_state(link_ptr: int) -> bool:
-    """
-    Returns a bool determining whether Link is in a valid or invalid state to receive items.
-
-    :return: True if Link is in a valid state, False if Link is in an invalid state
-    """
-    if link_ptr == 0x0 or get_link_state(link_ptr) in LINK_INVALID_STATES:
-        return False
-    else:
-        return True
-
-def validate_link_action(link_ptr: int) -> bool:
-    """
-    Returns a bool determining if Link is in a safe action to receive items.
-
-    :return: True if Link is in a safe action, False if Link is not in a safe action.
-    """
-    if link_ptr == 0x0:
-        return False
-    action = dme_read_byte(link_ptr + LINK_ACTION_OFFSET)
-    return action <= MAX_SAFE_ACTION
-
-def is_link_not_in_action(link_ptr: int, actions: List[int]) -> bool:
-    if link_ptr == 0x0:
-        return True
-
-    return get_link_action(link_ptr) not in actions
-
-def is_link_in_action(link_ptr: int, actions: List[int]) -> bool:
-    if link_ptr == 0x0:
-        return False
-
-    return get_link_action(link_ptr) in actions
-
-def check_on_file_1() -> bool:
-    """
-    Returns a bool determining if the player is currently on File 1.
-
-    :return: True if File 1 last selected, False otherwise
-    """
-    file = dme_read_byte(SELECTED_FILE_ADDR)
-    return file == 0x0
-
-def can_receive_items(ctx: SSContext) -> bool:
-    """
-    Link must be on File 1 in a valid state and action and not on the title screen to receive items.
-    """
-
-    link_ptr = get_link_ptr()
-    return (
-        link_ptr != 0x0
-        and can_send_items()
-        and check_alive()
-        and validate_link_state(link_ptr)
-        and validate_link_action(link_ptr)
-        and not check_in_minigame()
-        and ctx.current_stage_name != DEMISE_STAGE
-    )
-
-def can_send_items() -> bool:
-    """
-    Link must be on File 1 and not on the tile screen to send items.
-    """
-    return (not check_on_title_screen()) and check_on_file_1()
-
-
-async def dolphin_sync_task(ctx: SSContext) -> None:
-    """
-    Manages the connection to Dolphin.
+    Manages the connection to Dolphin or the game.
 
     While connected, read the emulator's memory to look for any relevant changes made by the player in the game.
 
@@ -695,65 +1127,123 @@ async def dolphin_sync_task(ctx: SSContext) -> None:
     """
     logger.info("Connecting to Dolphin. Use /dolphin for status information.")
     while not ctx.exit_event.is_set():
-        try:
-            if (
-                dolphin_memory_engine.is_hooked()
-                and ctx.dolphin_status == CONNECTION_CONNECTED_STATUS
-            ):
-                ctx.show_messages_ingame()
-                if not check_ingame(get_link_ptr()):
-                    # Reset the give item array while not in the game.
-                    # dolphin_memory_engine.write_bytes(ARCHIPELAGO_ARRAY_ADDR, bytes([0xFF] * ctx.len_give_item_array))
-                    await asyncio.sleep(0.1)
-                    continue
-                if ctx.slot is not None:
-                    if "DeathLink" in ctx.tags:
-                        await check_death(ctx)
-                    await give_items(ctx)
-                    await check_locations(ctx)
-                    await check_current_stage_changed(ctx)
-                else:
-                    if not ctx.auth:
-                        ctx.auth = dme_read_slot()
-                    if ctx.awaiting_rom:
-                        await ctx.server_auth()
-                await asyncio.sleep(0.1)
-            else:
-                if ctx.dolphin_status == CONNECTION_CONNECTED_STATUS:
-                    logger.info("Connection to Dolphin lost, reconnecting...")
-                    ctx.dolphin_status = CONNECTION_LOST_STATUS
-                logger.info("Attempting to connect to Dolphin...")
-                dolphin_memory_engine.hook()
-                if dolphin_memory_engine.is_hooked():
-                    if dme_read_string(0x80000000, 6) != "SOUE01":
-                        logger.info(CONNECTION_REFUSED_GAME_STATUS)
-                        ctx.dolphin_status = CONNECTION_REFUSED_GAME_STATUS
-                        dolphin_memory_engine.un_hook()
-                        await asyncio.sleep(5)
+        if ctx.on_console:
+            try:
+                if ctx.is_hooked():
+                    await ctx.cache_link_data()
+                    await ctx.show_messages_ingame()
+                    if not ctx.check_ingame():
+                        await asyncio.sleep(0.1)
+                        continue
+                    if ctx.slot is not None:
+                        if "DeathLink" in ctx.tags:
+                            await ctx.check_death()
+                        await ctx.give_items()
+                        await ctx.check_locations()
+                        await ctx.check_current_stage_changed()
                     else:
-                        logger.info(CONNECTION_CONNECTED_STATUS)
-                        ctx.dolphin_status = CONNECTION_CONNECTED_STATUS
-                        ctx.locations_checked = set()
-                        ctx.text_buffer_address = dme_read_long(CLIENT_TEXT_BUFFER_PTR)
+                        if not ctx.auth:
+                            ctx.auth = await ctx.read_slot()
+                        if ctx.awaiting_rom:
+                            await ctx.server_auth()
+                    await asyncio.sleep(0.1)
                 else:
-                    logger.info(
-                        "Connection to Dolphin failed, attempting again in 5 seconds..."
-                    )
-                    ctx.dolphin_status = CONNECTION_LOST_STATUS
+                    logger.info("Attempting to connect to the console...")
+                    ctx.close_wii_client()
+                    ctx.start_wii_client(ctx.wii_ip)
+                    await ctx.wii_memory_client.connect()
+
+                    if ctx.wii_memory_client.established:
+                        logger.info(CONSOLE_CONNECTED_STATUS)
+                        ctx.locations_checked = set()
+                        ctx.text_buffer_address = await ctx.read_long(CLIENT_TEXT_BUFFER_PTR)
+                        await ctx.cache_link_data()
+                    else:
+                        logger.info(
+                            "Connection to console failed, attempting again in 5 seconds..."
+                        )
+                        await ctx.disconnect()
+                        await asyncio.sleep(5)
+                        continue
+            except TimeoutError:
+                logger.info(
+                    "Lost packet from console, attempting to reconnect..."
+                )
+                ctx.close_wii_client()
+                ctx.start_wii_client(ctx.wii_ip)
+                if not await ctx.wii_memory_client.connect():
                     await ctx.disconnect()
                     await asyncio.sleep(5)
-                    continue
-        except Exception:
-            dolphin_memory_engine.un_hook()
-            logger.info(
-                "Connection to Dolphin failed, attempting again in 5 seconds..."
-            )
-            logger.error(traceback.format_exc())
-            ctx.dolphin_status = CONNECTION_LOST_STATUS
-            await ctx.disconnect()
-            await asyncio.sleep(5)
-            continue
-
+                else:
+                    logger.info(
+                        "Reconnected successfully."
+                    )
+                continue
+            except Exception:
+                ctx.close_wii_client()
+                logger.info(
+                    "Connection to console failed, attempting again in 5 seconds..."
+                )
+                logger.error(traceback.format_exc())
+                await ctx.disconnect()
+                await asyncio.sleep(5)
+                continue
+        else:
+            try:
+                if ctx.is_hooked():
+                    await ctx.cache_link_data()
+                    await ctx.show_messages_ingame()
+                    if not ctx.check_ingame():
+                        await asyncio.sleep(0.1)
+                        continue
+                    if ctx.slot is not None:
+                        if "DeathLink" in ctx.tags:
+                            await ctx.check_death()
+                        await ctx.give_items()
+                        await ctx.check_locations()
+                        await ctx.check_current_stage_changed()
+                    else:
+                        if not ctx.auth:
+                            ctx.auth = await ctx.read_slot()
+                        if ctx.awaiting_rom:
+                            await ctx.server_auth()
+                    await asyncio.sleep(0.1)
+                else:
+                    if ctx.dolphin_status == CONNECTION_CONNECTED_STATUS:
+                        logger.info("Connection to Dolphin lost, reconnecting...")
+                        ctx.dolphin_status = CONNECTION_LOST_STATUS
+                    logger.info("Attempting to connect to Dolphin...")
+                    dolphin_memory_engine.hook()
+                    if dolphin_memory_engine.is_hooked():
+                        if await ctx.read_string(0x80000000, 6) != "SOUE01":
+                            logger.info(CONNECTION_REFUSED_GAME_STATUS)
+                            ctx.dolphin_status = CONNECTION_REFUSED_GAME_STATUS
+                            dolphin_memory_engine.un_hook()
+                            await asyncio.sleep(5)
+                        else:
+                            logger.info(CONNECTION_CONNECTED_STATUS)
+                            ctx.dolphin_status = CONNECTION_CONNECTED_STATUS
+                            ctx.locations_checked = set()
+                            ctx.text_buffer_address = await ctx.read_long(CLIENT_TEXT_BUFFER_PTR)
+                            await ctx.cache_link_data()
+                    else:
+                        logger.info(
+                            "Connection to Dolphin failed, attempting again in 5 seconds..."
+                        )
+                        ctx.dolphin_status = CONNECTION_LOST_STATUS
+                        await ctx.disconnect()
+                        await asyncio.sleep(5)
+                        continue
+            except Exception:
+                dolphin_memory_engine.un_hook()
+                logger.info(
+                    "Connection to Dolphin failed, attempting again in 5 seconds..."
+                )
+                logger.error(traceback.format_exc())
+                ctx.dolphin_status = CONNECTION_LOST_STATUS
+                await ctx.disconnect()
+                await asyncio.sleep(5)
+                continue
 
 def main(connect: Optional[str] = None, password: Optional[str] = None) -> None:
     """
@@ -772,8 +1262,8 @@ def main(connect: Optional[str] = None, password: Optional[str] = None) -> None:
         ctx.run_cli()
         await asyncio.sleep(1)
 
-        ctx.dolphin_sync_task = asyncio.create_task(
-            dolphin_sync_task(ctx), name="DolphinSync"
+        ctx.sync_task = asyncio.create_task(
+            do_sync_task(ctx), name="GameSync"
         )
 
         await ctx.exit_event.wait()
@@ -781,9 +1271,9 @@ def main(connect: Optional[str] = None, password: Optional[str] = None) -> None:
 
         await ctx.shutdown()
 
-        if ctx.dolphin_sync_task:
+        if ctx.sync_task:
             await asyncio.sleep(3)
-            await ctx.dolphin_sync_task
+            await ctx.sync_task
 
     import colorama
 

--- a/worlds/ss/SSClientUtils.py
+++ b/worlds/ss/SSClientUtils.py
@@ -119,9 +119,15 @@ STAGE_TO_SCENEFLAG_ADDR = {
     "Skyloft Silent Realm": 0x80957058,
 }
 
+# Used for batch lookup
+STORYFLAG_START_ADDR = 0x805A9AD8
+SCENEFLAG_START_ADDR = 0x80956EC8
+
 # DME Connection Messages for the client
 CONNECTION_REFUSED_GAME_STATUS = "Dolphin failed to connect. Please load a randomized ROM for Skyward Sword. Trying again in 5 seconds..."
 CONNECTION_REFUSED_SAVE_STATUS = "Dolphin failed to connect. Please load into the save file. Trying again in 5 seconds..."
 CONNECTION_LOST_STATUS = "Dolphin connection was lost. Please restart your emulator and make sure Skyward Sword is running."
 CONNECTION_CONNECTED_STATUS = "Dolphin connected successfully."
 CONNECTION_INITIAL_STATUS = "Dolphin connection has not been initiated."
+
+CONSOLE_CONNECTED_STATUS = "Wii connected successfully."


### PR DESCRIPTION
## What is this fixing or adding?
Adds a Wii connection client that uses a UDP socket to communicate with a Wii on the local network for AP (see https://github.com/Battlecats59/sslib/pull/14). It may be activated by typing `/console [IP]` in the client.

The structure of the client was refactored somewhat to accomodate the Wii client (which must be async). Additionally, as of now, I'm using a queue of commands with a minimum delay as I assumed the crashes I was running into initially were due to console-specific rate limits, but that may not be necessary now that the crashes have been fixed. When checking for checked locations, instead of reading the corresponding byte from memory for each location, the client will fetch all sceneflags and storyflags at once, and look up the right flag from the loaded buffer, drastically reducing the number of queries necessary per iteration.

## How was this tested?
I played through some of a solo seed on my console and verified it properly sent/received items to/from the Wii.