### PR TITLE
SS: Add a client command to toggle deathlink and fix plando

### DIFF
--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -45,7 +45,17 @@ class SSCommandProcessor(ClientCommandProcessor):
         Display the current Dolphin emulator connection status.
         """
         if isinstance(self.ctx, SSContext):
-            logger.info(f"Dolphin Status: {self.ctx.dolphin_status}")
+            logger.info(f"Dolphin Status: {self.ctx.dolphin_status}") 
+            
+    def _cmd_deathlink(self) -> None:
+        """Toggle DeathLink."""
+        if isinstance(self.ctx, SSContext):
+            if "DeathLink" in self.ctx.tags:
+                Utils.async_start(self.ctx.update_death_link(False))
+                logger.info("Deathlink disabled.")
+            else:
+                Utils.async_start(self.ctx.update_death_link(True))
+                logger.info("Deathlink enabled.")
 
 
 class SSContext(CommonContext):
@@ -796,3 +806,4 @@ if __name__ == "__main__":
     parser = get_base_parser()
     args = parser.parse_args()
     main(args.connect, args.password)
+

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -561,6 +561,8 @@ class SSWorld(World):
 
         # Output options to file.
         for field in fields(self.options):
+            if field.name =="plando_items":
+                continue # Skip adding plando_items to patchfile 
             output_data["Options"][field.name.replace("_", "-")] = getattr(
                 self.options, field.name
             ).value
@@ -723,3 +725,4 @@ class SSWorld(World):
         }
 
         return slot_data
+


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Make it possible to enable or disable deathlink through the client aswell
Exclude adding Plando_items to the patchfile options
## How was this tested?
testing sending and recieving deaths with it enabled and disabled 

## If this makes graphical changes, please attach screenshots.
