### PR TITLE
Adjust the chest dowsing discription for goddess chests

### DIFF
--- a/worlds/ss/Options.py
+++ b/worlds/ss/Options.py
@@ -816,7 +816,7 @@ class ChestDowsing(Choice):
         (after obtaining the necessary song or Sea Chart first).
     **All Chests**: dowsing points to all chests (regardless of their contents).
     **Progress Items**: dowsing only points to chests containing progress items
-        (doesn't work with Goddess Chests).
+        (Goddess Chests must be activated by their respective Goddess Cube before being dowsable)).
     """
 
     display_name = "Chest Dowsing"
@@ -949,3 +949,4 @@ class SSOptions(PerGameCommonOptions):
     starting_items: StartInventoryPool
     death_link: DeathLink
     progression_balancing: SSProgressionBalancing
+


### PR DESCRIPTION
Chestdowsing works for goddess cubes when they are activated by their respective Cube, so this discription reflects that

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?


## How was this tested?


## If this makes graphical changes, please attach screenshots.
