### PR TITLE
Auto-reconnect to multiworld server if console client drops connection

### DIFF
--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -299,6 +299,7 @@ class SSContext(CommonContext):
         self.last_rcvd_index: int = -1
         self.has_send_death: bool = False
         self.locations_for_hint: dict[str, list] = {}
+        self.lost_client_connection: bool = False
 
         self.hints_checked = set()  # local variable
         self.checked_hints = set()  # server variable
@@ -1034,6 +1035,11 @@ async def do_sync_task(ctx: SSContext) -> None:
                         ctx.locations_checked = set()
                         ctx.text_buffer_address = await ctx.read_long(CLIENT_TEXT_BUFFER_PTR)
                         await ctx.cache_link_data()
+                        if ctx.lost_client_connection:
+                            logger.info("Attempting to reconnect to the server.")
+                            await ctx.connect()
+                        
+                        ctx.lost_client_connection = False
                     else:
                         logger.info(
                             "Connection to console failed, attempting again in 5 seconds..."
@@ -1046,6 +1052,7 @@ async def do_sync_task(ctx: SSContext) -> None:
                 ctx.close_wii_client()
                 ctx.start_wii_client(ctx.wii_ip)
                 if not await ctx.wii_memory_client.connect():
+                    ctx.lost_client_connection = True
                     logger.info("Lost packet from console and couldn't reconnect. Attempting again in 5 seconds...")
                     await ctx.disconnect()
                     await asyncio.sleep(5)


### PR DESCRIPTION
## What is this fixing or adding?
Sometimes the client console can drop a packet and also drop its "reconnect" packet, which drops connection to the multiworld server. This just makes it so it will auto-reconnect if it re-establishes connection to the console, for convenience.

## How was this tested?
I closed my game while connected to my console (which dropped the connection), then I reopened the game. Eventually, the client auto-reconnected to the console and then to the multiworld server on its own.