### PR TITLE
Delay slotdata filling before hints finish processing

### DIFF
--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from dataclasses import fields
 from typing import Any, ClassVar
 
+import threading
 import yaml
 
 from BaseClasses import MultiWorld, Region, Tutorial, LocationProgressType, ItemClassification as IC
@@ -153,6 +154,8 @@ class SSWorld(World):
 
         self.dungeons = DungeonRando(self)
         self.entrances = EntranceRando(self)
+
+        self.hints_ready = threading.Event()
 
     def determine_progress_and_nonprogress_locations(self) -> tuple[set[str], set[str]]:
         """
@@ -516,7 +519,8 @@ class SSWorld(World):
         #     locs[i] = sorted([(loc.name, loc.item.name) for loc in sphere], key=lambda loc: loc[0])
         # with open("./worlds/ss/Playthrough.json", "w") as f:
         #     json.dump(locs, f, indent=2)
-        
+        self.hints_ready.set()
+          
         multiworld = self.multiworld
         player = self.player
         player_hash = self.random.sample(HASH_NAMES, 3)
@@ -651,6 +655,9 @@ class SSWorld(World):
 
         :return: A dictionary to be sent to the client when it connects to the server.
         """
+        #Make sure slotdata doesnt fill before hints are ready from generate output 
+        self.hints_ready.wait()
+
         slot_data = {
             "required_dungeon_count": self.options.required_dungeon_count.value,
             "triforce_required": self.options.triforce_required.value,


### PR DESCRIPTION
  In rare scenarios slotdata would fill before hints finished being handled, resulting in issues for the client interpetering it from slotdata, resulting in being unable to connect to the room, this delays it till after hints are finished 