### PR TITLE
Remove textboxes for minor items (client compatibility)

### DIFF
--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -632,7 +632,7 @@ class SSContext(CommonContext):
 
         :return: The string containing the slot name.
         """
-        slot_bytes = await self.read_bytes(ARCHIPELAGO_ARRAY_ADDR + 0x14, 0x10)
+        slot_bytes = await self.read_bytes(ARCHIPELAGO_SLOT_ADDR, 0x10)
         slot_bytes = slot_bytes.replace(b"\xFF", b"")
 
         return slot_bytes.decode("utf-8")
@@ -701,28 +701,6 @@ class SSContext(CommonContext):
             await self.write_byte(ARCHIPELAGO_ITEM_INDEX, item_id)
             await asyncio.sleep(0.25)
             await self.cache_link_data() # Recalculate State & Action
-            # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
-            # or bed which could delete the item, so we should check for a reload
-            while await self.read_byte(ARCHIPELAGO_IS_ITEM_LOADING) != 0x00:
-                await asyncio.sleep(0.2)
-                await self.cache_link_data() # Recalculate State & Action
-                # While the client won't initiate an item send while the player is swimming, the player
-                # can still receive items underwater if they're sent one just before entering the water.
-                # The patched game *will* still give them the item, but it won't put them in the item action,
-                # so we shouldn't resend the item, or else it will be duplicated.
-                # if self.is_link_in_action(SWIM_ACTIONS):
-                #    break
-                # If state is 0, that means a reload occurred, so we should resend the item.
-                # However, we shouldn't resend the item if the user immediately enters the item get action anyway
-                # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
-                if not self.check_ingame():
-                    # Reset the value at this array index to 0, to avoid duplicating the item if it was never read in the first place
-                    await self.write_byte(ARCHIPELAGO_ITEM_INDEX, 0xFF)
-                    await self.write_byte(ARCHIPELAGO_IS_ITEM_LOADING, 0x00)
-                    debug_text = f"DEBUG: A reload deleted {self.player_names[self.slot]}'s {item_name} (ID {item_id}). Resending the item..."
-                    logger.info(debug_text)
-                    self.forward_client_message(debug_text)
-                    return False
             return True
 
         # If unable to place the item in the array, return False.
@@ -749,6 +727,7 @@ class SSContext(CommonContext):
                         await self.cache_link_data()
 
                     # Increment the expected index.
+                    # await asyncio.sleep(0.25)
                     await self.write_short(EXPECTED_INDEX_ADDR, idx + 1)
 
 
@@ -1003,7 +982,7 @@ class SSContext(CommonContext):
             and self.validate_link_state()
             and self.validate_link_action()
             and not await self.check_in_minigame()
-            and self.current_stage_name != DEMISE_STAGE
+            and self.can_get_items_on_stage(self.current_stage_name)
         )
 
     async def can_send_items(self) -> bool:
@@ -1011,6 +990,19 @@ class SSContext(CommonContext):
         Link must be on File 1 and not on the tile screen to send items.
         """
         return (not await self.check_on_title_screen()) and await self.check_on_file_1()
+    
+    def can_get_items_on_stage(self, stage_name: str) -> bool:
+        # don't receive items in a boss arena or post-boss arena
+        if stage_name.startswith('B'):
+            return False
+        
+        # don't receive items in sealed temple before getting the Song from Impa
+        # (yes this is hacky)
+        if stage_name == "F402":
+            return SSLocation.get_apid(89) in self.locations_checked
+        
+        return True
+
 
 async def do_sync_task(ctx: SSContext) -> None:
     """

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -785,9 +785,9 @@ class SSContext(CommonContext):
                 flag = storyflags.lookup_byte(addr + flag_bit)
                 checked = bool(flag & flag_value)
 
-                #if checked or self.finished_game:
-                    #for locname in self.locations_for_hint.get(hint, []):
-                    #    self.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
+                if checked or self.finished_game:
+                    for locname in self.locations_for_hint.get(hint, []):
+                        self.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
 
             for i, (name, (flag_bit, flag_value, addr)) in enumerate(cubes_table):
                 flag = storyflags.lookup_byte(addr + flag_bit)

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -329,9 +329,6 @@ class SSContext(CommonContext):
         # It starts as `None` until it has been read from the server.
         self.visited_stage_names: Optional[set[str]] = None
 
-        # Length of the item get array in memory.
-        self.len_give_item_array: int = 0x1  # TODO CHANGE TO 0x10 WHEN GAME IS FIXED
-
     async def disconnect(self, allow_autoreconnect: bool = False) -> None:
         """
         Disconnect the client from the server and reset game state variables.
@@ -694,16 +691,17 @@ class SSContext(CommonContext):
 
         item_id = ITEM_TABLE[item_name].item_id  # In game item ID
 
-        # Loop through the item array, placing the item in an empty slot (0xFF).
-        slot = await self.read_byte(ARCHIPELAGO_ITEM_INDEX)
+        # Read the item slot, and place the item here if the slot is empty.
+        # When the game confirms the player received the item, it'll clear out this slot again.
+        slot = await self.read_byte(ARCHIPELAGO_ITEM_SLOT)
         if slot == 0xFF:
             # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
-            await self.write_byte(ARCHIPELAGO_ITEM_INDEX, item_id)
+            await self.write_byte(ARCHIPELAGO_ITEM_SLOT, item_id)
             await asyncio.sleep(0.25)
             await self.cache_link_data() # Recalculate State & Action
             return True
 
-        # If unable to place the item in the array, return False.
+        # If unable to give the item, return False
         return False
 
 
@@ -727,7 +725,6 @@ class SSContext(CommonContext):
                         await self.cache_link_data()
 
                     # Increment the expected index.
-                    # await asyncio.sleep(0.25)
                     await self.write_short(EXPECTED_INDEX_ADDR, idx + 1)
 
 

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -695,35 +695,35 @@ class SSContext(CommonContext):
         item_id = ITEM_TABLE[item_name].item_id  # In game item ID
 
         # Loop through the item array, placing the item in an empty slot (0xFF).
-        for idx in range(self.len_give_item_array):
-            slot = await self.read_byte(ARCHIPELAGO_ARRAY_ADDR + idx)
-            if slot == 0xFF:
-                # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
-                await self.write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, item_id)
-                await asyncio.sleep(0.25)
+        slot = await self.read_byte(ARCHIPELAGO_ITEM_INDEX)
+        if slot == 0xFF:
+            # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
+            await self.write_byte(ARCHIPELAGO_ITEM_INDEX, item_id)
+            await asyncio.sleep(0.25)
+            await self.cache_link_data() # Recalculate State & Action
+            # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
+            # or bed which could delete the item, so we should check for a reload
+            while await self.read_byte(ARCHIPELAGO_IS_ITEM_LOADING) != 0x00:
+                await asyncio.sleep(0.2)
                 await self.cache_link_data() # Recalculate State & Action
-                # If this happens, this may be an indicator that the player interrupted the itemget with something like a Fi call
-                # or bed which could delete the item, so we should check for a reload
-                while self.is_link_not_in_action([ITEM_GET_ACTION]):
-                    await asyncio.sleep(0.2)
-                    await self.cache_link_data() # Recalculate State & Action
-                    # While the client won't initiate an item send while the player is swimming, the player
-                    # can still receive items underwater if they're sent one just before entering the water.
-                    # The patched game *will* still give them the item, but it won't put them in the item action,
-                    # so we shouldn't resend the item, or else it will be duplicated.
-                    if self.is_link_in_action(SWIM_ACTIONS):
-                        break
-                    # If state is 0, that means a reload occurred, so we should resend the item.
-                    # However, we shouldn't resend the item if the user immediately enters the item get action anyway
-                    # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
-                    if not self.check_ingame():
-                        # Reset the value at this array index to 0, to avoid duplicating the item if it was never read in the first place
-                        await self.write_byte(ARCHIPELAGO_ARRAY_ADDR + idx, 0xFF)
-                        debug_text = f"DEBUG: A reload deleted {self.player_names[self.slot]}'s {item_name} (ID {item_id}). Resending the item..."
-                        logger.info(debug_text)
-                        self.forward_client_message(debug_text)
-                        return False
-                return True
+                # While the client won't initiate an item send while the player is swimming, the player
+                # can still receive items underwater if they're sent one just before entering the water.
+                # The patched game *will* still give them the item, but it won't put them in the item action,
+                # so we shouldn't resend the item, or else it will be duplicated.
+                # if self.is_link_in_action(SWIM_ACTIONS):
+                #    break
+                # If state is 0, that means a reload occurred, so we should resend the item.
+                # However, we shouldn't resend the item if the user immediately enters the item get action anyway
+                # (which can happen if this reload occurs due to a door, in which case the original item will still be received)
+                if not self.check_ingame():
+                    # Reset the value at this array index to 0, to avoid duplicating the item if it was never read in the first place
+                    await self.write_byte(ARCHIPELAGO_ITEM_INDEX, 0xFF)
+                    await self.write_byte(ARCHIPELAGO_IS_ITEM_LOADING, 0x00)
+                    debug_text = f"DEBUG: A reload deleted {self.player_names[self.slot]}'s {item_name} (ID {item_id}). Resending the item..."
+                    logger.info(debug_text)
+                    self.forward_client_message(debug_text)
+                    return False
+            return True
 
         # If unable to place the item in the array, return False.
         return False
@@ -809,9 +809,9 @@ class SSContext(CommonContext):
                 flag = storyflags.lookup_byte(addr + flag_bit)
                 checked = bool(flag & flag_value)
 
-                if checked or self.finished_game:
-                    for locname in self.locations_for_hint.get(hint, []):
-                        self.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
+                #if checked or self.finished_game:
+                    #for locname in self.locations_for_hint.get(hint, []):
+                    #    self.hints_checked.add(SSLocation.get_apid(LOCATION_TABLE[locname].code))
 
             for i, (name, (flag_bit, flag_value, addr)) in enumerate(cubes_table):
                 flag = storyflags.lookup_byte(addr + flag_bit)

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -329,6 +329,8 @@ class SSContext(CommonContext):
         # It starts as `None` until it has been read from the server.
         self.visited_stage_names: Optional[set[str]] = None
 
+        self.len_item_buffer = 6 # length of the item ring buffer in-game
+
     async def disconnect(self, allow_autoreconnect: bool = False) -> None:
         """
         Disconnect the client from the server and reset game state variables.

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -693,10 +693,17 @@ class SSContext(CommonContext):
 
         # Read the item slot, and place the item here if the slot is empty.
         # When the game confirms the player received the item, it'll clear out this slot again.
-        slot = await self.read_byte(ARCHIPELAGO_ITEM_SLOT)
-        if slot == 0xFF:
+        slots = await self.read_short(ARCHIPELAGO_ITEM_SLOT)
+        main_slot, secondary_slot = slots >> 8, slots & 0xFF
+        if main_slot == 0xFF:
             # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
             await self.write_byte(ARCHIPELAGO_ITEM_SLOT, item_id)
+            await asyncio.sleep(0.25)
+            await self.cache_link_data() # Recalculate State & Action
+            return True
+        elif secondary_slot == 0xFF:
+            # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
+            await self.write_byte(ARCHIPELAGO_ITEM_SLOT + 1, item_id)
             await asyncio.sleep(0.25)
             await self.cache_link_data() # Recalculate State & Action
             return True
@@ -944,7 +951,7 @@ class SSContext(CommonContext):
         """
         if self.link_ptr == 0x0:
             return False
-        return self.link_action <= MAX_SAFE_ACTION
+        return self.link_action <= MAX_SAFE_ACTION or self.link_action == ITEM_GET_ACTION
 
     def is_link_not_in_action(self, actions: List[int]) -> bool:
         if self.link_ptr == 0x0:

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -329,7 +329,7 @@ class SSContext(CommonContext):
         # It starts as `None` until it has been read from the server.
         self.visited_stage_names: Optional[set[str]] = None
 
-        self.len_item_buffer = 6 # length of the item ring buffer in-game
+        self.len_item_buffer = 14 # length of the item ring buffer in-game
 
     async def disconnect(self, allow_autoreconnect: bool = False) -> None:
         """
@@ -697,7 +697,7 @@ class SSContext(CommonContext):
         # When the game confirms the player received the item, it'll clear out this slot again.
         slots = await self.read_bytes(ARCHIPELAGO_ITEM_SLOT, self.len_item_buffer)
         for i, slot in enumerate(slots):
-            if slot == 0xFF:
+            if slot == 0:
                 # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
                 await self.write_byte(ARCHIPELAGO_ITEM_SLOT + i, item_id)
                 await asyncio.sleep(0.25)
@@ -979,10 +979,11 @@ class SSContext(CommonContext):
             self.link_ptr != 0x0
             and await self.can_send_items()
             and await self.check_alive()
-            and self.validate_link_state()
-            and self.validate_link_action()
-            and not await self.check_in_minigame()
-            and self.can_get_items_on_stage(self.current_stage_name)
+            # These are now handled in-game
+            # and self.validate_link_state()
+            # and self.validate_link_action()
+            # and not await self.check_in_minigame()
+            # and self.can_get_items_on_stage(self.current_stage_name)
         )
 
     async def can_send_items(self) -> bool:

--- a/worlds/ss/SSClient.py
+++ b/worlds/ss/SSClient.py
@@ -693,20 +693,14 @@ class SSContext(CommonContext):
 
         # Read the item slot, and place the item here if the slot is empty.
         # When the game confirms the player received the item, it'll clear out this slot again.
-        slots = await self.read_short(ARCHIPELAGO_ITEM_SLOT)
-        main_slot, secondary_slot = slots >> 8, slots & 0xFF
-        if main_slot == 0xFF:
-            # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
-            await self.write_byte(ARCHIPELAGO_ITEM_SLOT, item_id)
-            await asyncio.sleep(0.25)
-            await self.cache_link_data() # Recalculate State & Action
-            return True
-        elif secondary_slot == 0xFF:
-            # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
-            await self.write_byte(ARCHIPELAGO_ITEM_SLOT + 1, item_id)
-            await asyncio.sleep(0.25)
-            await self.cache_link_data() # Recalculate State & Action
-            return True
+        slots = await self.read_bytes(ARCHIPELAGO_ITEM_SLOT, self.len_item_buffer)
+        for i, slot in enumerate(slots):
+            if slot == 0xFF:
+                # logger.info(f"DEBUG: Gave item {item_id} to player {ctx.player_names[ctx.slot]}.")
+                await self.write_byte(ARCHIPELAGO_ITEM_SLOT + i, item_id)
+                await asyncio.sleep(0.25)
+                await self.cache_link_data() # Recalculate State & Action
+                return True
 
         # If unable to give the item, return False
         return False

--- a/worlds/ss/SSClientUtils.py
+++ b/worlds/ss/SSClientUtils.py
@@ -39,17 +39,15 @@ SELECTED_FILE_ADDR = 0x8095FC98
 # The expected index for the following item that should be received. Array of 2 bytes right after the give item array
 # Uses an unused scene index which is 16 bytes wide
 EXPECTED_INDEX_ADDR = 0x80956F28 # HALFWORD
-# WILL BE UPDATED WHEN THE BUILD IS RELEASED
 
 # This address contains the current stage ID.
 CURR_STAGE_ADDR = 0x805B388C  # STRING[16]
 
-# This is an array of length 0x10 where each element is a byte and contains item IDs for items to give the player.
-# 0xFF represents no item. The array is read and cleared every frame.
-# ARCHIPELAGO_ARRAY_ADDR = 0x80678770 # ARRAY[16]
+# The patcher will write the AP slot name at this address
 ARCHIPELAGO_SLOT_ADDR = 0x806786A0
-# WILL BE UPDATED WHEN THE BUILD IS RELEASED
-ARCHIPELAGO_ITEM_INDEX = EXPECTED_INDEX_ADDR + 2
+
+# A byte here represents what item ID to give to the player. The game will clear this out and give items whenever possible.
+ARCHIPELAGO_ITEM_SLOT = EXPECTED_INDEX_ADDR + 2
 
 # This is the address that holds the player's file name.
 FILE_NAME_ADDR = 0x80955D38  # ARRAY[16]

--- a/worlds/ss/SSClientUtils.py
+++ b/worlds/ss/SSClientUtils.py
@@ -46,10 +46,10 @@ CURR_STAGE_ADDR = 0x805B388C  # STRING[16]
 
 # This is an array of length 0x10 where each element is a byte and contains item IDs for items to give the player.
 # 0xFF represents no item. The array is read and cleared every frame.
-ARCHIPELAGO_ARRAY_ADDR = 0x80678770 # ARRAY[16]
+# ARCHIPELAGO_ARRAY_ADDR = 0x80678770 # ARRAY[16]
+ARCHIPELAGO_SLOT_ADDR = 0x806786A0
 # WILL BE UPDATED WHEN THE BUILD IS RELEASED
-ARCHIPELAGO_ITEM_INDEX = 0x80686D90
-ARCHIPELAGO_IS_ITEM_LOADING = 0x8068690C
+ARCHIPELAGO_ITEM_INDEX = EXPECTED_INDEX_ADDR + 2
 
 # This is the address that holds the player's file name.
 FILE_NAME_ADDR = 0x80955D38  # ARRAY[16]

--- a/worlds/ss/SSClientUtils.py
+++ b/worlds/ss/SSClientUtils.py
@@ -48,6 +48,8 @@ CURR_STAGE_ADDR = 0x805B388C  # STRING[16]
 # 0xFF represents no item. The array is read and cleared every frame.
 ARCHIPELAGO_ARRAY_ADDR = 0x80678770 # ARRAY[16]
 # WILL BE UPDATED WHEN THE BUILD IS RELEASED
+ARCHIPELAGO_ITEM_INDEX = 0x80686D90
+ARCHIPELAGO_IS_ITEM_LOADING = 0x8068690C
 
 # This is the address that holds the player's file name.
 FILE_NAME_ADDR = 0x80955D38  # ARRAY[16]


### PR DESCRIPTION
## What is this fixing or adding?
Updates the client to work with the patcher update that removes textboxes for minor items and reduces potential for item duplication / deletion (see https://github.com/Battlecats59/sslib/pull/16)

## How was this tested?
I loaded a 2 player game where the other slot released everything to confirm that all the itemget events played out as expected.