### PR TITLE
move hints to finalise multiworld

### DIFF
--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from dataclasses import fields
 from typing import Any, ClassVar
 
-import threading
 import yaml
 
 from BaseClasses import MultiWorld, Region, Tutorial, LocationProgressType, ItemClassification as IC
@@ -155,7 +154,6 @@ class SSWorld(World):
         self.dungeons = DungeonRando(self)
         self.entrances = EntranceRando(self)
 
-        self.hints_ready = threading.Event()
 
     def determine_progress_and_nonprogress_locations(self) -> tuple[set[str], set[str]]:
         """
@@ -490,8 +488,21 @@ class SSWorld(World):
             )
         raise KeyError(f"Invalid item name: {name}")
     
- #   def post_fill(self):
+    def finalize_multiworld(self):
+        """
+        Finalize the multiworld after all worlds have been generated. This is where you can do any final adjustments to the world before it is output.
+        """
 
+         # Fill hint data
+        self.hints = Hints(self)
+        self.hints.handle_hints()
+
+        # spheres = self.multiworld.get_spheres()
+        # locs = {}
+        # for i, sphere in enumerate(spheres):
+        #     locs[i] = sorted([(loc.name, loc.item.name) for loc in sphere], key=lambda loc: loc[0])
+        # with open("./worlds/ss/Playthrough.json", "w") as f:
+        #     json.dump(locs, f, indent=2)
 
     def region_to_hint_region(self, region: Region) -> str:
         """
@@ -509,18 +520,7 @@ class SSWorld(World):
 
         :param output_directory: The output directory for the .apssr file.
         """
-                # Fill hint data
-        self.hints = Hints(self)
-        self.hints.handle_hints()
 
-        # spheres = self.multiworld.get_spheres()
-        # locs = {}
-        # for i, sphere in enumerate(spheres):
-        #     locs[i] = sorted([(loc.name, loc.item.name) for loc in sphere], key=lambda loc: loc[0])
-        # with open("./worlds/ss/Playthrough.json", "w") as f:
-        #     json.dump(locs, f, indent=2)
-        self.hints_ready.set()
-          
         multiworld = self.multiworld
         player = self.player
         player_hash = self.random.sample(HASH_NAMES, 3)
@@ -655,8 +655,6 @@ class SSWorld(World):
 
         :return: A dictionary to be sent to the client when it connects to the server.
         """
-        #Make sure slotdata doesnt fill before hints are ready from generate output 
-        self.hints_ready.wait()
 
         slot_data = {
             "required_dungeon_count": self.options.required_dungeon_count.value,


### PR DESCRIPTION
Removed workaround for race condition causing hints not to fill, fill hints in finalize multiworld before slotdata or generate output happen. SImplifies handling and fixes unittests deadlocks