### PR TITLE
AP Locations Creation

### DIFF
--- a/worlds/ss/Locations.py
+++ b/worlds/ss/Locations.py
@@ -258,7 +258,7 @@ LOCATION_TABLE: dict[str, SSLocData] = {
     ),
     # Central Skyloft
     "Central Skyloft - Potion Lady's Gift": SSLocData(
-        13, 
+        13,
         SSLocFlag.ALWAYS,
         "Central Skyloft",
         "F004r",

--- a/worlds/ss/Locations.py
+++ b/worlds/ss/Locations.py
@@ -258,7 +258,7 @@ LOCATION_TABLE: dict[str, SSLocData] = {
     ),
     # Central Skyloft
     "Central Skyloft - Potion Lady's Gift": SSLocData(
-        13,
+        13, 
         SSLocFlag.ALWAYS,
         "Central Skyloft",
         "F004r",

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -316,6 +316,7 @@ class SSWorld(World):
             for short_loc_name, rule in data["locations"].items():
                 full_loc_name = f"{data["hint_region"]} - {short_loc_name}"
                 og_full_loc_name = deepcopy(full_loc_name)
+                loc_data = LOCATION_TABLE[full_loc_name]
                 if LOCATION_TABLE[full_loc_name].flags & SSLocFlag.BTREAUX:
                     # Remove location from progress or nonprogress locations
                     if full_loc_name in self.progress_locations:
@@ -361,7 +362,8 @@ class SSWorld(World):
                         location.progress_type = LocationProgressType.EXCLUDED
                 else:
                     if full_loc_name in self.nonprogress_locations:
-                        continue
+                        if not (loc_data.flags & (SSLocFlag.BEEDLE | SSLocFlag.ALWAYS)):
+                            continue
                     # Create a normal location
                     location = SSLocation(self.player, full_loc_name, region, LOCATION_TABLE[full_loc_name])
                 region.locations.append(location)

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -357,6 +357,8 @@ class SSWorld(World):
 
                     # Create a batreaux reward location
                     location = SSLocation(self.player, full_loc_name, region, LOCATION_TABLE[og_full_loc_name], ogname=og_full_loc_name)
+                    if not bat_loc_progress:
+                        location.progress_type = LocationProgressType.EXCLUDED
                 else:
                     if full_loc_name in self.nonprogress_locations:
                         continue

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -152,6 +152,7 @@ class SSWorld(World):
 
         self.progress_locations: set[str] = set()
         self.nonprogress_locations: set[str] = set()
+        self.overflow_items: list[str] = []
 
         self.dungeons = DungeonRando(self)
         self.entrances = EntranceRando(self)
@@ -643,21 +644,27 @@ class SSWorld(World):
                     output_data["Locations"][location.ogname] = item_info
                 else:
                     output_data["Locations"][location.name] = item_info
+        ap_location_names = {loc.name for loc in multiworld.get_locations(player)}
 
         for location in self.nonprogress_locations:
+            if location in ap_location_names:
+                continue
             loc_data = LOCATION_TABLE.get(location)
 
             if loc_data is None:
                 item_name = "Red Rupee"
             else:    
-                #decide if want to place vanilla item or fallback to red rupee
+                # decide if we want to place the vanilla item or fill based on overflow pool
                 is_trial_relic = loc_data.type == SSLocType.RELIC
                 is_rupee_location = loc_data.flags == SSLocFlag.RUPEE
 
                 if is_trial_relic or is_rupee_location:
                     item_name = loc_data.vanilla_item
                 else:
-                    item_name = "Red Rupee"
+                    if self.overflow_items:
+                        item_name = self.overflow_items.pop()
+                    else:
+                        item_name = "Red Rupee"
                 item_info = {
                     "player": self.player,
                     "name": item_name,

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -584,7 +584,6 @@ class SSWorld(World):
             "Starting Statues": self.entrances.starting_statues,
             "Starting Entrance": self.entrances.starting_entrance,
         }
-        print("Entrances:", output_data["Entrances"])
         # Output options to file.
         for field in fields(self.options):
             if field.name =="plando_items":
@@ -599,11 +598,6 @@ class SSWorld(World):
                 output_data["Excluded Locations"].add(self.batreaux_ognames[loc])
             else:
                 output_data["Excluded Locations"].add(loc)
-        #for loc in self.nonprogress_locations:
-            #if self.get_location(loc).ogname:
-                #output_data["Excluded Locations"].add(self.get_location(loc).ogname)
-            #else:
-               #output_data["Excluded Locations"].add(loc)
 
         # Unused options in AP must be filled for the patcher
         output_data["Options"]["limit-start-entrance"] = 0

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -166,6 +166,7 @@ class SSWorld(World):
 
         progress_locations: set[str] = set()
         nonprogress_locations: set[str] = set()
+        trial_relic_amount = self.options.trial_treasure_amount.value
 
         def add_flag(option: Toggle, flag: SSLocFlag) -> SSLocFlag:
             return flag if option else SSLocFlag.ALWAYS
@@ -242,6 +243,12 @@ class SSWorld(World):
                     progress_locations.add(loc)
                 else:
                     nonprogress_locations.add(loc)
+            elif (self.options.treasuresanity_in_silent_realms 
+                  and data.flags & SSLocFlag.TRIAL and data.type == SSLocType.RELIC 
+                  and int(loc.split(" ")[-1]) > trial_relic_amount
+                  ):
+                nonprogress_locations.add(loc)
+
             elif data.flags & enabled_flags == data.flags:
                 progress_locations.add(loc)
             else:

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -131,7 +131,7 @@ class SSWorld(World):
     web = SSWeb()
     required_client_version: tuple[int, int, int] = (0, 5, 6)
     origin_region_name: str = "" # This is set later
-    explicit_indirect_conditions = True 
+    explicit_indirect_conditions = False 
     
     item_name_to_id: ClassVar[dict[str, int]] = {
         name: SSItem.get_apid(data.code)
@@ -347,10 +347,10 @@ class SSWorld(World):
                     # Create a batreaux reward location
                     location = SSLocation(self.player, full_loc_name, region, LOCATION_TABLE[og_full_loc_name], ogname=og_full_loc_name)
                 else:
+                    if full_loc_name in self.nonprogress_locations:
+                        continue
                     # Create a normal location
                     location = SSLocation(self.player, full_loc_name, region, LOCATION_TABLE[full_loc_name])
-                if full_loc_name in self.nonprogress_locations:
-                    location.progress_type = LocationProgressType.EXCLUDED
                 region.locations.append(location)
             self.multiworld.regions.append(region)
 
@@ -375,6 +375,8 @@ class SSWorld(World):
 
         for loc in LOCATION_TABLE.keys():
             if LOCATION_TABLE[loc].region == "Batreaux's House":
+                continue
+            if loc in self.nonprogress_locations:
                 continue
             assert self.get_location(loc), f"Location found in location table, but not in requirements: {loc}"
 
@@ -588,11 +590,11 @@ class SSWorld(World):
             ).value
 
         # Excluded locations, and account for batreaux checks
-        for loc in self.nonprogress_locations:
-            if self.get_location(loc).ogname:
-                output_data["Excluded Locations"].add(self.get_location(loc).ogname)
-            else:
-                output_data["Excluded Locations"].add(loc)
+       # for loc in self.nonprogress_locations:
+        #    if self.get_location(loc).ogname:
+         #       output_data["Excluded Locations"].add(self.get_location(loc).ogname)
+          #  else:
+           #     output_data["Excluded Locations"].add(loc)
 
         # Unused options in AP must be filled for the patcher
         output_data["Options"]["limit-start-entrance"] = 0

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -28,7 +28,7 @@ from worlds.LauncherComponents import (
 from .Constants import *
 
 from .Items import ITEM_TABLE, SSItem
-from .Locations import LOCATION_TABLE, SSLocation, SSLocFlag
+from .Locations import LOCATION_TABLE, SSLocType, SSLocation, SSLocFlag
 from .Options import SSOptions
 from .Rules import set_rules
 from .Names import HASH_NAMES
@@ -632,6 +632,31 @@ class SSWorld(World):
                     output_data["Locations"][location.ogname] = item_info
                 else:
                     output_data["Locations"][location.name] = item_info
+
+        for location in self.nonprogress_locations:
+            loc_data = LOCATION_TABLE.get(location)
+
+            if loc_data is None:
+                item_name = "Red Rupee"
+            else:    
+                #decide if want to place vanilla item or fallback to red rupee
+                is_trial_relic = loc_data.type == SSLocType.RELIC
+                is_rupee_location = loc_data.flags == SSLocFlag.RUPEE
+
+                if is_trial_relic or is_rupee_location:
+                    item_name = loc_data.vanilla_item
+                else:
+                    item_name = "Red Rupee"
+                item_info = {
+                    "player": self.player,
+                    "name": item_name,
+                    "game": "Skyward Sword",
+                    "classification": "filler",
+                }
+                if location in self.batreaux_ognames:
+                    output_data["Locations"][self.batreaux_ognames[location]] = item_info
+                else:
+                    output_data["Locations"][location] = item_info
 
         # Output the plando details to file.
         apssr = SSContainer(

--- a/worlds/ss/__init__.py
+++ b/worlds/ss/__init__.py
@@ -297,6 +297,7 @@ class SSWorld(World):
 
         self.batreaux_rewards = shuffle_batreaux_counts(self)
         self.batreaux_requirements = {}
+        self.batreaux_ognames = {}
 
     def create_regions(self) -> None:
         """
@@ -327,16 +328,19 @@ class SSWorld(World):
                         short_loc_name = f"{str(crystal_count)} Crystals Chest"
                         full_loc_name = f"{data["hint_region"]} - {str(crystal_count)} Crystals Chest"
                         self.batreaux_requirements[short_loc_name] = f"{str(crystal_count)} Gratitude Crystals"
+                        self.batreaux_ognames[full_loc_name] = og_full_loc_name
                     elif short_loc_name == "Seventh Reward":
                         crystal_count = self.batreaux_rewards["Sixth Reward"]
                         short_loc_name = f"{str(crystal_count)} Crystals Second Reward"
                         full_loc_name = f"{data["hint_region"]} - {str(crystal_count)} Crystals Second Reward"
                         self.batreaux_requirements[short_loc_name] = f"{str(crystal_count)} Gratitude Crystals"
+                        self.batreaux_ognames[full_loc_name] = og_full_loc_name
                     else:
                         crystal_count = self.batreaux_rewards[short_loc_name]
                         short_loc_name = f"{str(crystal_count)} Crystals"
                         full_loc_name = f"{data["hint_region"]} - {str(crystal_count)} Crystals"
                         self.batreaux_requirements[short_loc_name] = f"{str(crystal_count)} Gratitude Crystals"
+                        self.batreaux_ognames[full_loc_name] = og_full_loc_name
 
                     # Add new location back into progress or nonprogress locations
                     if bat_loc_progress:
@@ -580,7 +584,7 @@ class SSWorld(World):
             "Starting Statues": self.entrances.starting_statues,
             "Starting Entrance": self.entrances.starting_entrance,
         }
-
+        print("Entrances:", output_data["Entrances"])
         # Output options to file.
         for field in fields(self.options):
             if field.name =="plando_items":
@@ -590,11 +594,16 @@ class SSWorld(World):
             ).value
 
         # Excluded locations, and account for batreaux checks
-       # for loc in self.nonprogress_locations:
-        #    if self.get_location(loc).ogname:
-         #       output_data["Excluded Locations"].add(self.get_location(loc).ogname)
-          #  else:
-           #     output_data["Excluded Locations"].add(loc)
+        for loc in self.nonprogress_locations:
+            if loc in self.batreaux_ognames:
+                output_data["Excluded Locations"].add(self.batreaux_ognames[loc])
+            else:
+                output_data["Excluded Locations"].add(loc)
+        #for loc in self.nonprogress_locations:
+            #if self.get_location(loc).ogname:
+                #output_data["Excluded Locations"].add(self.get_location(loc).ogname)
+            #else:
+               #output_data["Excluded Locations"].add(loc)
 
         # Unused options in AP must be filled for the patcher
         output_data["Options"]["limit-start-entrance"] = 0

--- a/worlds/ss/rando/DungeonRando.py
+++ b/worlds/ss/rando/DungeonRando.py
@@ -160,7 +160,13 @@ class DungeonKeyHandler:
                     if self.world.region_to_hint_region(loc.parent_region) == dun and loc.item is None:
                         locs_placeable[dun].append(tuple([loc.name, loc.player]))
         elif self.world.options.map_mode == "anywhere":
-            return []
+            for dun, map_item in self.all_maps.items():
+                if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+                    placed.extend([map_item]) 
+                    continue
+                if map_item in self.start_maps:
+                    continue
+            return placed
         for dun, map_item in self.all_maps.items():
             if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
                     placed.extend([map_item]) 
@@ -215,7 +221,10 @@ class DungeonKeyHandler:
                     for i, locs in keydata.items():
                         locs_placeable[dun][i] = [(loc, self.world.player) for loc in locs if not self.world.get_location(loc).item]
         elif self.world.options.small_key_mode == "anywhere":
-            return []
+            for dun, skey_items in self.all_skeys.items():
+                if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+                    placed.extend(skey_items)
+            return placed
         for dun, skey_items in self.all_skeys.items():
             dun_start_skeys = self.start_skeys.count(skey_items[0])
             if dun not in locs_placeable:
@@ -344,7 +353,10 @@ class DungeonKeyHandler:
                             continue
                         locs_placeable[dun].append(tuple([loc.name, loc.player]))
         elif self.world.options.boss_key_mode == "anywhere":
-            return []
+                for dun, bkey_item in self.all_bkeys.items():
+                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
+                        placed.extend([bkey_item])
+                return placed
         for dun, bkey_item in self.all_bkeys.items():
             if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
                 placed.append(bkey_item)

--- a/worlds/ss/rando/DungeonRando.py
+++ b/worlds/ss/rando/DungeonRando.py
@@ -137,7 +137,7 @@ class DungeonKeyHandler:
                     loc.place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
                 for dun, map_item in self.all_maps.items():
-                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and map_item not in placed):
+                    if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and map_item not in placed):
                         placed.extend([map_item])
             return placed
         elif self.world.options.map_mode == "own_dungeon_restricted":
@@ -222,7 +222,7 @@ class DungeonKeyHandler:
                         locs_placeable[dun][i] = [(loc, self.world.player) for loc in locs if not self.world.get_location(loc).item]
         elif self.world.options.small_key_mode == "anywhere":
             for dun, skey_items in self.all_skeys.items():
-                if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+                if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
                     placed.extend(skey_items)
             return placed
         for dun, skey_items in self.all_skeys.items():
@@ -334,7 +334,7 @@ class DungeonKeyHandler:
                     (loc).place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
                 for dun, bkey_item in self.all_bkeys.items():
-                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
+                    if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
                         placed.extend([bkey_item])
             return placed
         elif self.world.options.boss_key_mode == "own_dungeon":
@@ -354,11 +354,11 @@ class DungeonKeyHandler:
                         locs_placeable[dun].append(tuple([loc.name, loc.player]))
         elif self.world.options.boss_key_mode == "anywhere":
                 for dun, bkey_item in self.all_bkeys.items():
-                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
+                    if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
                         placed.extend([bkey_item])
                 return placed
         for dun, bkey_item in self.all_bkeys.items():
-            if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+            if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
                 placed.append(bkey_item)
                 continue
             if bkey_item in self.start_bkeys:

--- a/worlds/ss/rando/DungeonRando.py
+++ b/worlds/ss/rando/DungeonRando.py
@@ -136,6 +136,9 @@ class DungeonKeyHandler:
                         continue
                     loc.place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
+                for dun, map_item in self.all_maps.items():
+                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and map_item not in placed):
+                        placed.extend([map_item])
             return placed
         elif self.world.options.map_mode == "own_dungeon_restricted":
             for dun in self.all_maps.keys():
@@ -159,8 +162,9 @@ class DungeonKeyHandler:
         elif self.world.options.map_mode == "anywhere":
             return []
         for dun, map_item in self.all_maps.items():
-            if (not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons): 
-                continue
+            if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+                    placed.extend([map_item]) 
+                    continue
             if map_item in self.start_maps:
                 continue
             if len(locs_placeable[dun])== 0:
@@ -183,7 +187,9 @@ class DungeonKeyHandler:
         if self.world.options.small_key_mode == "vanilla":
             for dun, skey_items in self.all_skeys.items():
                 if dun not in self.progression_dungeons and self.world.options.empty_unrequired_dungeons:
-                    continue
+                        for skey in skey_items:
+                            placed.extend([skey])
+                        continue
                 dun_start_skeys = self.start_skeys.count(skey_items[0])
                 for i, skey in enumerate(skey_items):
                     if i < dun_start_skeys:
@@ -213,14 +219,17 @@ class DungeonKeyHandler:
         for dun, skey_items in self.all_skeys.items():
             dun_start_skeys = self.start_skeys.count(skey_items[0])
             if dun not in locs_placeable:
+                    if self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons:
+                        for skey in skey_items:
+                            placed.append(skey)
                     continue
             for i, skey in enumerate(skey_items):
-                if (not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons):
+                if (self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
                      continue
                 if i < dun_start_skeys:
                     continue
                 if len(locs_placeable[dun][i]) == 0:
-                    if (not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons):
+                    if (self.world.options.empty_unrequired_dungeons == False and dun not in self.progression_dungeons):
                         raise FillError(f"Could not find a location to place small key: {skey}")
                     else: 
                         continue
@@ -315,6 +324,9 @@ class DungeonKeyHandler:
                         continue
                     (loc).place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
+                for dun, bkey_item in self.all_bkeys.items():
+                    if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons and bkey_item not in placed):
+                        placed.extend([bkey_item])
             return placed
         elif self.world.options.boss_key_mode == "own_dungeon":
             for dun in self.all_bkeys.keys():
@@ -334,7 +346,8 @@ class DungeonKeyHandler:
         elif self.world.options.boss_key_mode == "anywhere":
             return []
         for dun, bkey_item in self.all_bkeys.items():
-            if(not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons):
+            if(self.world.options.empty_unrequired_dungeons == True and dun not in self.progression_dungeons):
+                placed.append(bkey_item)
                 continue
             if bkey_item in self.start_bkeys:
                 continue

--- a/worlds/ss/rando/DungeonRando.py
+++ b/worlds/ss/rando/DungeonRando.py
@@ -159,7 +159,7 @@ class DungeonKeyHandler:
         elif self.world.options.map_mode == "anywhere":
             return []
         for dun, map_item in self.all_maps.items():
-            if(not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons): 
+            if (not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons): 
                 continue
             if map_item in self.start_maps:
                 continue
@@ -201,7 +201,6 @@ class DungeonKeyHandler:
             for dun in list(locs_placeable.keys()):
                 if dun not in self.progression_dungeons and self.world.options.empty_unrequired_dungeons:
                     del locs_placeable[dun]
-            print(locs_placeable)
             for dun, keydata in locs_placeable.items():
                 if dun in self.progression_dungeons:
                     for i, locs in keydata.items():
@@ -270,16 +269,20 @@ class DungeonKeyHandler:
             ]:
                 # In this case, we must place the key in sand sea
                 locs_placeable.extend([
-                    loc for loc, data in LOCATION_TABLE.items()
-                    if data.region in ["Lanayru Sand Sea"]
-                    and self.world.get_location(loc).item is None
+                    loc.name
+                    for loc in self.multiworld.get_locations(self.world.player)
+                    if loc.name in LOCATION_TABLE
+                    and LOCATION_TABLE[loc.name].region in ["Lanayru Sand Sea"]
+                    and loc.item is None
                 ])
             else:
                 # Otherwise, place the key anywhere except sand sea
                 locs_placeable.extend([
-                    loc for loc, data in LOCATION_TABLE.items()
-                    if data.region in ["Lanayru Mine", "Lanayru Desert", "Lanayru Caves", "Lanayru Gorge"]
-                    and self.world.get_location(loc).item is None
+                    loc.name
+                    for loc in self.multiworld.get_locations(self.world.player)
+                    if loc.name in LOCATION_TABLE
+                    and LOCATION_TABLE[loc.name].region in ["Lanayru Mine", "Lanayru Desert", "Lanayru Caves", "Lanayru Gorge"]
+                    and loc.item is None
                 ])
         elif self.world.options.lanayru_caves_small_key == "anywhere":
             return []
@@ -331,7 +334,7 @@ class DungeonKeyHandler:
         elif self.world.options.boss_key_mode == "anywhere":
             return []
         for dun, bkey_item in self.all_bkeys.items():
-            if(not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons):
+            if(not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons):
                 continue
             if bkey_item in self.start_bkeys:
                 continue

--- a/worlds/ss/rando/DungeonRando.py
+++ b/worlds/ss/rando/DungeonRando.py
@@ -123,13 +123,18 @@ class DungeonKeyHandler:
         if self.world.options.map_mode == "start_with":
             raise FillError("Tried to place maps, but option is start with.")
         elif self.world.options.map_mode == "vanilla":
-            for loc, data in LOCATION_TABLE.items():
+            for loc in self.multiworld.get_locations(self.world.player):
+                data = LOCATION_TABLE.get(loc.name)
+                if not data:
+                    continue
                 if data.vanilla_item is None:
                     continue
                 if "Map" in data.vanilla_item:
                     if data.vanilla_item in self.start_maps:
                         continue
-                    self.world.get_location(loc).place_locked_item(self.world.create_item(data.vanilla_item))
+                    if loc.item:
+                        continue
+                    loc.place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
             return placed
         elif self.world.options.map_mode == "own_dungeon_restricted":
@@ -150,16 +155,19 @@ class DungeonKeyHandler:
                 locs_placeable[dun] = []
                 for loc in self.multiworld.get_locations(self.world.player):
                     if self.world.region_to_hint_region(loc.parent_region) == dun and loc.item is None:
-                        if loc.item:
-                            continue
                         locs_placeable[dun].append(tuple([loc.name, loc.player]))
         elif self.world.options.map_mode == "anywhere":
             return []
         for dun, map_item in self.all_maps.items():
+            if(not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons): 
+                continue
             if map_item in self.start_maps:
                 continue
-            if len(locs_placeable[dun]) == 0:
-                raise FillError(f"Could not find a location to place map: {map_item}")
+            if len(locs_placeable[dun])== 0:
+                if not self.world.options.empty_unrequired_dungeons:
+                    raise FillError(f"Could not find a location to place map: {map_item}")
+                else:
+                        continue
             loc_to_place = self.world.random.choice(locs_placeable[dun])
             self.world.get_location(loc_to_place[0]).place_locked_item(self.world.create_item(map_item))
             placed.append(map_item)
@@ -174,6 +182,8 @@ class DungeonKeyHandler:
         locs_placeable = {}
         if self.world.options.small_key_mode == "vanilla":
             for dun, skey_items in self.all_skeys.items():
+                if dun not in self.progression_dungeons and self.world.options.empty_unrequired_dungeons:
+                    continue
                 dun_start_skeys = self.start_skeys.count(skey_items[0])
                 for i, skey in enumerate(skey_items):
                     if i < dun_start_skeys:
@@ -188,6 +198,10 @@ class DungeonKeyHandler:
             return placed
         elif self.world.options.small_key_mode == "own_dungeon":
             locs_placeable = deepcopy(KEY_PLACEMENTS)
+            for dun in list(locs_placeable.keys()):
+                if dun not in self.progression_dungeons and self.world.options.empty_unrequired_dungeons:
+                    del locs_placeable[dun]
+            print(locs_placeable)
             for dun, keydata in locs_placeable.items():
                 if dun in self.progression_dungeons:
                     for i, locs in keydata.items():
@@ -200,14 +214,17 @@ class DungeonKeyHandler:
         for dun, skey_items in self.all_skeys.items():
             dun_start_skeys = self.start_skeys.count(skey_items[0])
             if dun not in locs_placeable:
-                if dun == "Lanayru Caves":
                     continue
-                raise FillError(f"Tried to fill unknown dungeon with small keys: {dun}")
             for i, skey in enumerate(skey_items):
+                if (not self.world.options.empty_unrequired_dungeons and dun not in self.progression_dungeons):
+                     continue
                 if i < dun_start_skeys:
                     continue
                 if len(locs_placeable[dun][i]) == 0:
-                    raise FillError(f"Could not find a location to place small key: {skey}")
+                    if (not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons):
+                        raise FillError(f"Could not find a location to place small key: {skey}")
+                    else: 
+                        continue
                 loc_to_place = self.world.random.choice(locs_placeable[dun][i])
                 self.world.get_location(loc_to_place[0]).place_locked_item(self.world.create_item(skey))
                 for keyindex in locs_placeable[dun].keys():
@@ -282,13 +299,18 @@ class DungeonKeyHandler:
         placed = []
         locs_placeable = {}
         if self.world.options.boss_key_mode == "vanilla":
-            for loc, data in LOCATION_TABLE.items():
+            for loc in self.multiworld.get_locations(self.world.player):
+                data = LOCATION_TABLE.get(loc.name)
+                if not data:
+                    continue
                 if data.vanilla_item is None:
                     continue
                 if "Boss Key" in data.vanilla_item:
                     if data.vanilla_item in self.start_bkeys:
                         continue
-                    self.world.get_location(loc).place_locked_item(self.world.create_item(data.vanilla_item))
+                    if loc.item:
+                        continue
+                    (loc).place_locked_item(self.world.create_item(data.vanilla_item))
                     placed.append(data.vanilla_item)
             return placed
         elif self.world.options.boss_key_mode == "own_dungeon":
@@ -309,10 +331,15 @@ class DungeonKeyHandler:
         elif self.world.options.boss_key_mode == "anywhere":
             return []
         for dun, bkey_item in self.all_bkeys.items():
+            if(not self.world.options.empty_unrequired_dungeons and dun not in self.world.dungeons.progression_dungeons):
+                continue
             if bkey_item in self.start_bkeys:
                 continue
             if len(locs_placeable[dun]) == 0:
-                raise FillError(f"Could not find a location to place boss key: {bkey_item}")
+                if not self.world.options.empty_unrequired_dungeons:
+                    raise FillError(f"Could not find a location to place boss key: {bkey_item}")
+                else:
+                    continue
             loc_to_place = self.world.random.choice(locs_placeable[dun])
             self.world.get_location(loc_to_place[0]).place_locked_item(self.world.create_item(bkey_item))
             placed.append(bkey_item)

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -67,6 +67,7 @@ def handle_itempool(world: "SSWorld") -> None:
             pool.remove(itm)
     
     pool = _fill_itempool(world, pool, filler_pool)
+    _fill_overflowpool(world)
 
     # Create the pool of the remaining shuffled items.
     items = [world.create_item(itm) for itm in pool]
@@ -141,10 +142,10 @@ def _fill_itempool(world: "SSWorld", pool: list[str], filler_pool: list[str]) ->
         filler_pool.extend(consumable_pool)
 
     elif num_items_needed < 0:
-        remove_count = min(-num_items_needed, len(filler_pool))
+        overflow_count = min(-num_items_needed, len(filler_pool))
         world.random.shuffle(filler_pool)
-        del filler_pool[:remove_count]
-        # If we have more than enough items, just remove some filler items from the pool
+        world.overflow_items.extend(filler_pool[:overflow_count])
+        del filler_pool[:overflow_count]
 
     world.random.shuffle(filler_pool)
 
@@ -170,6 +171,51 @@ def _fill_itempool(world: "SSWorld", pool: list[str], filler_pool: list[str]) ->
 
     return pool
 
+def _fill_overflowpool(world: "SSWorld") -> None:
+    """
+    Fills an overflow pool to fill the uncreated locations for the patchfile
+
+    :param world: The SS game world.
+    """
+    total_locations = len(LOCATION_TABLE)
+    ap_locations = len(world.multiworld.get_locations(world.player))
+  
+    if world.options.treasuresanity_in_silent_realms:
+        vanilla_dusk_relic_count =  40 - (
+            world.options.trial_treasure_amount.value * 4
+        )
+    else:
+        vanilla_dusk_relic_count = 40
+
+    if not world.options.rupeesanity:
+        rupeesanity_vanilla_location_count = 0
+        for data in LOCATION_TABLE.values():
+            if data.flags & SSLocFlag.RUPEE:
+                rupeesanity_vanilla_location_count += 1
+        excluded_rupee_locations_count = rupeesanity_vanilla_location_count
+    else:
+        excluded_rupee_locations_count = 0
+
+    # calculate the amount of overflow locations to be filled
+    overflow_count = (
+        total_locations
+        -ap_locations
+        -vanilla_dusk_relic_count
+        -excluded_rupee_locations_count
+        -len(world.overflow_items)
+    )
+
+    if overflow_count <= 0:
+        return
+    
+        # Fill overflow with weighted consumables
+    overflow_pool = world.random.choices(
+        list(CONSUMABLE_ITEMS.keys()),
+        weights=list(CONSUMABLE_ITEMS.values()),
+        k=overflow_count,
+    )
+    world.random.shuffle(overflow_pool)
+    world.overflow_items.extend(overflow_pool)
 
 def _handle_starting_items(world: "SSWorld") -> list[str]:
     """

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -5,7 +5,6 @@ from BaseClasses import LocationProgressType
 from Fill import FillError
 from Options import OptionError
 
-
 from ..Items import ITEM_TABLE, CONSUMABLE_ITEMS
 from ..Locations import LOCATION_TABLE, SSLocType, SSLocFlag
 from ..Constants import *
@@ -325,13 +324,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
                 # If we can't place any more tadtones, put a junk item here
                 tad.progress_type = LocationProgressType.EXCLUDED
 
-    if not options.rupeesanity:
-        for loc, data in LOCATION_TABLE.items():
-            if data.flags & SSLocFlag.RUPEE:
-                world.get_location(loc).place_locked_item(
-                    world.create_item(data.vanilla_item)
-                )
-                placed.append(data.vanilla_item)
+
 
     if not options.gondo_upgrades:
         placed.extend(GONDO_UPGRADES)
@@ -374,7 +367,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
             placed.append("Progressive Sword")
 
     # Vanilla Triforces
-    if options.triforce_shuffle == "vanilla":
+    if options.triforce_shuffle == "vanilla" and (options.triforce_required or not options.empty_unrequired_dungeons):
         world.get_location("Sky Keep - Sacred Power of Din").place_locked_item(world.create_item("Triforce of Power"))
         world.get_location("Sky Keep - Sacred Power of Nayru").place_locked_item(world.create_item("Triforce of Wisdom"))
         world.get_location("Sky Keep - Sacred Power of Farore").place_locked_item(world.create_item("Triforce of Courage"))
@@ -391,7 +384,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
         placed.extend(world.dungeons.key_handler.place_dungeon_maps())
 
     # Non-vanilla Triforces
-    if options.triforce_shuffle == "sky_keep":
+    if options.triforce_shuffle == "sky_keep" and (options.triforce_required or not options.empty_unrequired_dungeons):
         locations_to_place = [loc for loc in world.multiworld.get_locations(world.player) if world.region_to_hint_region(loc.parent_region) == "Sky Keep" and not loc.item]
         triforce_locations = world.random.sample(locations_to_place, 3)
         world.random.shuffle(triforce_locations)

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-import logging
+
 from BaseClasses import ItemClassification as IC
 from BaseClasses import LocationProgressType
 from Fill import FillError
@@ -90,7 +90,6 @@ def _create_base_itempool(world: "SSWorld") -> tuple[list[str], list[str], list[
     progression_pool: list[str] = []
     useful_pool: list[str] = []
     filler_pool: list[str] = []
-
     for item, data in ITEM_TABLE.items():
         if data.type in ["Item", "Small Key", "Boss Key", "Map"]:
             adjusted_classification = item_classification(world, item)

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -324,8 +324,6 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
                 # If we can't place any more tadtones, put a junk item here
                 tad.progress_type = LocationProgressType.EXCLUDED
 
-
-
     if not options.gondo_upgrades:
         placed.extend(GONDO_UPGRADES)
         # We're not actually going to place these in the world, the rando will patch them in

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -4,8 +4,7 @@ from BaseClasses import ItemClassification as IC
 from BaseClasses import LocationProgressType
 from Fill import FillError
 from Options import OptionError
-from rule_builder import options
-from worlds.apquest import world
+
 
 from ..Items import ITEM_TABLE, CONSUMABLE_ITEMS
 from ..Locations import LOCATION_TABLE, SSLocType, SSLocFlag
@@ -338,7 +337,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
         placed.extend(GONDO_UPGRADES)
         # We're not actually going to place these in the world, the rando will patch them in
         # Still, remove them from the item pool
-        
+
     ### DUNGEON PLACEMENTS
 
     # Place vanilla keys first to prevent location overlap

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -90,6 +90,7 @@ def _create_base_itempool(world: "SSWorld") -> tuple[list[str], list[str], list[
     progression_pool: list[str] = []
     useful_pool: list[str] = []
     filler_pool: list[str] = []
+
     for item, data in ITEM_TABLE.items():
         if data.type in ["Item", "Small Key", "Boss Key", "Map"]:
             adjusted_classification = item_classification(world, item)
@@ -389,7 +390,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
         for i, tri in enumerate(["Triforce of Power", "Triforce of Wisdom", "Triforce of Courage"]):
             triforce_locations[i].place_locked_item(world.create_item(tri))
         placed.extend(["Triforce of Power", "Triforce of Wisdom", "Triforce of Courage"])
-        
+
     return placed
 
 
@@ -419,37 +420,6 @@ def item_classification(world: "SSWorld", name: str) -> IC | None:
             if name == "Stone of Trials":
                 adjusted_classification = IC.filler
     
-    # Dungeon Items
-    if (
-        world.options.empty_unrequired_dungeons
-        and item_type in ["Map", "Small Key", "Boss Key"]
-    ):
-        if item_type == "Map":
-            item_dungeon = name[:-4]
-            if item_dungeon == "Sky Keep":
-                adjusted_classification = IC.filler if not world.dungeons.sky_keep_required else None
-            elif not item_dungeon in world.dungeons.required_dungeons:
-                adjusted_classification = IC.filler
-                # If map not a required dungeon, make it filler
-                # Otherwise, it will be useful
-        if item_type == "Small Key":
-            item_dungeon = name[:-10]
-            if item_dungeon == "Sky Keep":
-                adjusted_classification = IC.filler if not world.dungeons.sky_keep_required else None
-            elif item_dungeon == "Lanayru Caves":
-                pass
-                # Caves key will always stay progression
-            elif not item_dungeon in world.dungeons.required_dungeons:
-                adjusted_classification = IC.filler
-                # If small key not a required dungeon, make it filler
-                # Otherwise, it will be progression
-        if item_type == "Boss Key":
-            item_dungeon = name[:-9]
-            if not item_dungeon in world.dungeons.required_dungeons:
-                adjusted_classification = IC.filler
-                # If boss key not a required dungeon, make it filler
-                # Otherwise, it will be progression
-
     # Triforces
     if not world.options.triforce_required:
         if "Triforce" in name:

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -389,7 +389,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
         for i, tri in enumerate(["Triforce of Power", "Triforce of Wisdom", "Triforce of Courage"]):
             triforce_locations[i].place_locked_item(world.create_item(tri))
         placed.extend(["Triforce of Power", "Triforce of Wisdom", "Triforce of Courage"])
-
+        
     return placed
 
 

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -127,7 +127,6 @@ def _fill_itempool(world: "SSWorld", pool: list[str], filler_pool: list[str]) ->
     for loc in world.multiworld.get_locations(world.player):
         if not loc.item:
             num_items_needed += 1
-
     num_items_needed -= len(pool)
     num_items_needed -= len(filler_pool)
 
@@ -284,20 +283,6 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
                 world.create_item("Gratitude Crystal")
             )
             placed.append("Gratitude Crystal")
-
-    if not options.treasuresanity_in_silent_realms:
-        for loc in world.get_locations():
-            if getattr(loc, "type", None) == SSLocType.RELIC:
-                loc.place_locked_item(world.create_item("Dusk Relic"))
-                placed.append("Dusk Relic")
-    else:
-        num_relics = options.trial_treasure_amount.value
-        for trl in TRIAL_LIST:
-            all_relics = [loc for loc in world.multiworld.get_locations(world.player) if loc.parent_region == world.get_region(trl) and loc.type == SSLocType.RELIC]
-            relics_to_place = [rel for rel in all_relics if int(rel.name.split(" ")[-1]) > num_relics]
-            for rel in relics_to_place:
-                rel.place_locked_item(world.create_item("Dusk Relic"))
-                placed.append("Dusk Relic")
 
     if not options.shopsanity:
         for loc, data in LOCATION_TABLE.items():

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -1,9 +1,11 @@
 from typing import TYPE_CHECKING
-
+import logging
 from BaseClasses import ItemClassification as IC
 from BaseClasses import LocationProgressType
 from Fill import FillError
 from Options import OptionError
+from rule_builder import options
+from worlds.apquest import world
 
 from ..Items import ITEM_TABLE, CONSUMABLE_ITEMS
 from ..Locations import LOCATION_TABLE, SSLocType, SSLocFlag
@@ -286,11 +288,9 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
             placed.append("Gratitude Crystal")
 
     if not options.treasuresanity_in_silent_realms:
-        for loc, data in LOCATION_TABLE.items():
-            if data.type == SSLocType.RELIC:
-                world.get_location(loc).place_locked_item(
-                    world.create_item("Dusk Relic")
-                )
+        for loc in world.get_locations():
+            if getattr(loc, "type", None) == SSLocType.RELIC:
+                loc.place_locked_item(world.create_item("Dusk Relic"))
                 placed.append("Dusk Relic")
     else:
         num_relics = options.trial_treasure_amount.value
@@ -338,7 +338,7 @@ def _handle_placements(world: "SSWorld", pool: list[str]) -> list[str]:
         placed.extend(GONDO_UPGRADES)
         # We're not actually going to place these in the world, the rando will patch them in
         # Still, remove them from the item pool
-
+        
     ### DUNGEON PLACEMENTS
 
     # Place vanilla keys first to prevent location overlap

--- a/worlds/ss/rando/ItemPlacement.py
+++ b/worlds/ss/rando/ItemPlacement.py
@@ -91,6 +91,13 @@ def _create_base_itempool(world: "SSWorld") -> tuple[list[str], list[str], list[
     useful_pool: list[str] = []
     filler_pool: list[str] = []
     for item, data in ITEM_TABLE.items():
+        quantity = data.quantity
+        if item == "Dusk Relic":
+            if world.options.treasuresanity_in_silent_realms:
+                quantity = world.options.trial_treasure_amount.value * 4 + 1
+            else:
+                quantity = 1
+
         if data.type in ["Item", "Small Key", "Boss Key", "Map"]:
             adjusted_classification = item_classification(world, item)
             classification = (
@@ -100,16 +107,11 @@ def _create_base_itempool(world: "SSWorld") -> tuple[list[str], list[str], list[
             )
 
             if classification == IC.progression or classification == IC.progression_skip_balancing:
-                progression_pool.extend([item] * data.quantity)
+                progression_pool.extend([item] * quantity)
             elif classification == IC.useful:
-                useful_pool.extend([item] * data.quantity)
+                useful_pool.extend([item] * quantity)
             else:
-                filler_pool.extend([item] * data.quantity)
-
-    if not world.options.rupeesanity:
-        filler_pool.extend([data.vanilla_item for loc, data in LOCATION_TABLE.items() if data.flags & SSLocFlag.RUPEE])
-            # Put all placed rupees in filler pool if rupeesanity is on
-            # These will be removed from the pool and manually placed vanilla
+                filler_pool.extend([item] * quantity)
 
     return progression_pool, useful_pool, filler_pool
 
@@ -130,12 +132,20 @@ def _fill_itempool(world: "SSWorld", pool: list[str], filler_pool: list[str]) ->
     num_items_needed -= len(pool)
     num_items_needed -= len(filler_pool)
 
-    consumable_pool = world.random.choices(
-        list(CONSUMABLE_ITEMS.keys()),
-        weights=list(CONSUMABLE_ITEMS.values()),
-        k=num_items_needed,
-    )
-    filler_pool.extend(consumable_pool)
+    if num_items_needed > 0:
+        consumable_pool = world.random.choices(
+            list(CONSUMABLE_ITEMS.keys()),
+            weights=list(CONSUMABLE_ITEMS.values()),
+            k=num_items_needed,
+        )
+        filler_pool.extend(consumable_pool)
+
+    elif num_items_needed < 0:
+        remove_count = min(-num_items_needed, len(filler_pool))
+        world.random.shuffle(filler_pool)
+        del filler_pool[:remove_count]
+        # If we have more than enough items, just remove some filler items from the pool
+
     world.random.shuffle(filler_pool)
 
     # Now fill rupoors


### PR DESCRIPTION
Implements not creating locations excluded by the settings in the yaml resulting in a lower showing amount in the AP lobby and more representive amount of checks for getting hint points to use the hint command. 

Removes dungeon items for uncreated dungeons from the pool
Moves vanilla placements of relics not randomized and rupeesanity if not randomized to patch file handling
fills the removed locations in patchfile with removed filler and consumable items from the pool (creating is neccessary due to crashes if empty locations are cleared) 
